### PR TITLE
Fix MCLPaginator._currentAmount being None in populate()

### DIFF
--- a/lib/windows/pagination.py
+++ b/lib/windows/pagination.py
@@ -35,7 +35,7 @@ class MCLPaginator(object):
 
     def reset(self):
         self.offset = 0
-        self._currentAmount = None
+        self._currentAmount = 0
         self._lastAmount = None
         self._boundaryHit = False
         self._direction = None


### PR DESCRIPTION
Without this, I was seeing the error below in the logs and the page for
a certain TV show was unusable. It wouldn't show a cursor and I couldn't
select any season.

```
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```