### PR TITLE
Upstreaming changes from ZidooPlexMod fork

### DIFF
--- a/lib/_included_packages/plexnet/plexserver.py
+++ b/lib/_included_packages/plexnet/plexserver.py
@@ -179,6 +179,17 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
 
     def query(self, path, method=None, **kwargs):
         method = method or self.session.get
+
+        params = kwargs.pop("params", None)
+        if params:
+            path += util.joinArgs(params, '?' not in path)
+
+        offset = kwargs.pop("offset", None)
+        limit = kwargs.pop("limit", None)
+        if kwargs:
+            path += util.joinArgs(kwargs, '?' not in path)
+            kwargs.clear()
+
         url = self.buildUrl(path, includeToken=True)
 
         # If URL is empty, try refresh resources and return empty set for now
@@ -188,8 +199,6 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
             return None
 
         # add offset/limit
-        offset = kwargs.pop("offset", None)
-        limit = kwargs.pop("limit", None)
         if offset is not None:
             url = http.addUrlParam(url, "X-Plex-Container-Start=%s" % offset)
         if limit is not None:

--- a/lib/_included_packages/plexnet/video.py
+++ b/lib/_included_packages/plexnet/video.py
@@ -88,6 +88,19 @@ class Video(media.MediaItem):
 
     def selectStream(self, stream, _async=True):
         self.mediaChoice.part.setSelectedStream(stream.streamType.asInt(), stream.id, _async)
+        # Update any affected streams
+        if stream.streamType.asInt() == plexstream.PlexStream.TYPE_AUDIO:
+            for audioStream in self.audioStreams:
+                if audioStream.id == stream.id:
+                    audioStream.setSelected(True)
+                elif audioStream.isSelected():
+                    audioStream.setSelected(False)
+        elif stream.streamType.asInt() == plexstream.PlexStream.TYPE_SUBTITLE:
+            for subtitleStream in self.subtitleStreams:
+                if subtitleStream.id == stream.id:
+                    subtitleStream.setSelected(True)
+                elif subtitleStream.isSelected():
+                    subtitleStream.setSelected(False)
 
     def isVideoItem(self):
         return True

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -26,6 +26,9 @@ from . import pagination
 from lib.util import T
 from six.moves import range
 
+import time
+import re
+
 VIDEO_RELOAD_KW = dict(includeExtras=1, includeExtrasCount=10, includeChapters=1)
 
 
@@ -940,12 +943,16 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
     def setProgress(self, mli):
         video = mli.dataSource
-
+        remainingTime = None
         if video.viewOffset.asInt():
             width = video.viewOffset.asInt() and (1 + int((video.viewOffset.asInt() / video.duration.asFloat()) * self.width)) or 1
             self.progressImageControl.setWidth(width)
+            remainingTime = time.strftime("%Hh %Mm left", time.gmtime((video.duration.asInt() - video.viewOffset.asInt()) / 1000))
+            remainingTime = re.sub(r'0(\d[hm])', r'\1', remainingTime).replace('0h ', '').replace(' 0m', '')
         else:
             self.progressImageControl.setWidth(1)
+
+        mli.setProperty('remainingTime', remainingTime)
 
     def createListItem(self, episode):
         if episode.index:

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -665,17 +665,22 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
         resume = False
         if episode.viewOffset.asInt():
-            button = optionsdialog.show(
-                T(32314, 'In Progress'),
-                T(32315, 'Resume playback?'),
-                T(32316, 'Resume'),
-                T(32317, 'Play From Beginning')
+            choice = dropdown.showDropdown(
+                options=[
+                    {'key': 'resume', 'display': T(32429, 'Resume from {0}').format(util.timeDisplay(episode.viewOffset.asInt()).lstrip('0').lstrip(':'))},
+                    {'key': 'play', 'display': T(32317, 'Play from beginning')}
+                ],
+                pos=(660, 441),
+                close_direction='none',
+                set_dropdown_prop=False,
+                header=T(32314, 'In Progress')
             )
 
-            if button is None:
+            if not choice:
                 return
 
-            resume = (button == 0)
+            if choice['key'] == 'resume':
+                resume = True
 
         pl = playlist.LocalPlaylist(self.show_.all(), self.show_.getServer())
         if len(pl):  # Don't use playlist if it's only this video

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -242,32 +242,31 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         # HOME
         'home.continue': {'index': 0, 'with_progress': True, 'with_art': True, 'do_updates': True, 'text2lines': True},
         'home.ondeck': {'index': 1, 'with_progress': True, 'do_updates': True, 'text2lines': True},
-        'home.television.recent': {'index': 2, 'text2lines': True, 'text2lines': True},
-        'home.movies.recent': {'index': 4, 'text2lines': True},
+        'home.television.recent': {'index': 2, 'with_progress': True, 'text2lines': True},
+        'home.movies.recent': {'index': 4, 'with_progress': True, 'text2lines': True},
         'home.music.recent': {'index': 5, 'text2lines': True},
-        'home.videos.recent': {'index': 6, 'ar16x9': True},
-        'home.playlists': {'index': 9},
+        'home.videos.recent': {'index': 6, 'with_progress': True, 'ar16x9': True},
+        #'home.playlists': {'index': 9}, # No other Plex home screen shows playlists so removing it from here
         'home.photos.recent': {'index': 10, 'text2lines': True},
         # SHOW
         'tv.ondeck': {'index': 1, 'with_progress': True, 'do_updates': True, 'text2lines': True},
-        'tv.recentlyaired': {'index': 2, 'text2lines': True},
-        'tv.recentlyadded': {'index': 3, 'text2lines': True},
+        'tv.recentlyaired': {'index': 2, 'with_progress': True, 'text2lines': True},
+        'tv.recentlyadded': {'index': 3, 'with_progress': True, 'text2lines': True},
         'tv.inprogress': {'index': 4, 'with_progress': True, 'do_updates': True, 'text2lines': True},
-        'tv.startwatching': {'index': 7},
-        'tv.rediscover': {'index': 8},
-        'tv.morefromnetwork': {'index': 13},
-        'tv.toprated': {'index': 14},
-        'tv.moreingenre': {'index': 15},
-        'tv.recentlyviewed': {'index': 16, 'text2lines': True},
+        'tv.startwatching': {'index': 7, 'with_progress': True},
+        'tv.rediscover': {'index': 8, 'with_progress': True},
+        'tv.morefromnetwork': {'index': 13, 'with_progress': True},
+        'tv.toprated': {'index': 14, 'with_progress': True},
+        'tv.moreingenre': {'index': 15, 'with_progress': True},
+        'tv.recentlyviewed': {'index': 16, 'with_progress': True, 'text2lines': True},
         # MOVIE
         'movie.inprogress': {'index': 0, 'with_progress': True, 'with_art': True, 'do_updates': True, 'text2lines': True},
-        'movie.recentlyreleased': {'index': 1, 'text2lines': True},
-        'movie.recentlyadded': {'index': 2, 'text2lines': True},
-        'movie.genre': {'index': 3, 'text2lines': True},
-        'movie.director': {'index': 7, 'text2lines': True},
-        'movie.actor': {'index': 8, 'text2lines': True},
+        'movie.recentlyreleased': {'index': 1, 'with_progress': True, 'text2lines': True},
+        'movie.recentlyadded': {'index': 2, 'with_progress': True, 'text2lines': True},
+        'movie.genre': {'index': 3, 'with_progress': True, 'text2lines': True},
+        'movie.by.actor.or.director': {'index': 7, 'with_progress': True, 'text2lines': True},
         'movie.topunwatched': {'index': 13, 'text2lines': True},
-        'movie.recentlyviewed': {'index': 14, 'text2lines': True},
+        'movie.recentlyviewed': {'index': 14, 'with_progress': True, 'text2lines': True},
         # ARTIST
         'music.recent.played': {'index': 5, 'do_updates': True},
         'music.recent.added': {'index': 9, 'text2lines': True},
@@ -286,12 +285,12 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         'photo.random.decade': {'index': 10, 'text2lines': True},
         'photo.random.dayormonth': {'index': 11, 'text2lines': True},
         # VIDEO
-        'video.recent': {'index': 0, 'ar16x9': True},
-        'video.random.year': {'index': 6, 'ar16x9': True},
-        'video.random.decade': {'index': 17, 'ar16x9': True},
-        'video.inprogress': {'index': 18, 'with_progress': True, 'ar16x9': True, 'do_updates': True},
+        'video.recent': {'index': 0, 'with_progress': True, 'ar16x9': True},
+        'video.random.year': {'index': 6, 'with_progress': True, 'ar16x9': True},
+        'video.random.decade': {'index': 17, 'with_progress': True, 'ar16x9': True},
+        'video.inprogress': {'index': 18, 'with_progress': True, 'ar16x9': True},
         'video.unwatched.random': {'index': 19, 'ar16x9': True},
-        'video.recentlyviewed': {'index': 23, 'ar16x9': True},
+        'video.recentlyviewed': {'index': 23, 'with_progress': True, 'ar16x9': True},
         # PLAYLISTS
         'playlists.audio': {'index': 5, 'text2lines': True, 'title': T(32048, 'Audio')},
         'playlists.video': {'index': 6, 'text2lines': True, 'ar16x9': True, 'title': T(32053, 'Video')},
@@ -576,7 +575,11 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         self.processCommand(search.dialog(self))
 
     def updateOnDeckHubs(self, **kwargs):
-        tasks = [UpdateHubTask().setup(hub, self.updateHubCallback) for hub in self.updateHubs.values()]
+        sections = set()
+        for mli in self.sectionList:
+            if mli.dataSource is not None and mli.dataSource != self.lastSection:
+                sections.add(mli.dataSource)
+        tasks = [SectionHubsTask().setup(s, self.sectionHubsCallback) for s in [self.lastSection] + list(sections)]
         self.tasks += tasks
         backgroundthread.BGThreader.addTasks(tasks)
 

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -1247,17 +1247,17 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
         if sectionType == 'collection':
             sectionType = mli.dataSource.TYPE
 
-        updateWatched = False
+        updateUnwatchedAndProgress = False
 
         if mli.dataSource.TYPE == 'collection':
             self.processCommand(opener.open(mli.dataSource))
-            updateWatched = True
+            updateUnwatchedAndProgress = True
         elif sectionType == 'show':
             if ITEM_TYPE == 'episode':
                 self.openItem(mli.dataSource)
             else:
                 self.processCommand(opener.handleOpen(subitems.ShowWindow, media_item=mli.dataSource, parent_list=self.showPanelControl))
-            updateWatched = True
+            updateUnwatchedAndProgress = True
         elif self.section.TYPE == 'movie' or mli.dataSource.TYPE == 'movie':
             datasource = mli.dataSource
             if datasource.isDirectory():
@@ -1275,7 +1275,7 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
                 self.librarySettings.setItemType(self.librarySettings.getItemType())
             else:
                 self.processCommand(opener.handleOpen(preplay.PrePlayWindow, video=datasource, parent_list=self.showPanelControl))
-                updateWatched = True
+                updateUnwatchedAndProgress = True
         elif self.section.TYPE == 'artist':
             if ITEM_TYPE == 'album':
                 self.openItem(mli.dataSource)
@@ -1291,8 +1291,8 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
             self.showPanelControl.removeItem(mli.pos())
             return
 
-        if updateWatched:
-            self.updateUnwatched(mli)
+        if updateUnwatchedAndProgress:
+            self.updateUnwatchedAndProgress(mli)
 
     def showPhoto(self, photo):
         if isinstance(photo, plexnet.photo.Photo) or photo.TYPE == 'clip':
@@ -1300,7 +1300,7 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
         else:
             self.processCommand(opener.sectionClicked(photo))
 
-    def updateUnwatched(self, mli):
+    def updateUnwatchedAndProgress(self, mli):
         mli.dataSource.reload()
         if mli.dataSource.isWatched:
             mli.setProperty('unwatched', '')
@@ -1310,6 +1310,7 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
                 mli.setProperty('unwatched.count', str(mli.dataSource.unViewedLeafCount))
             else:
                 mli.setProperty('unwatched', '1')
+        mli.setProperty('progress', util.getProgressImage(mli.dataSource))
 
     def setTitle(self):
         if self.section.TYPE == 'artist':
@@ -1726,6 +1727,8 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
                                     mli.setProperty('unwatched.count', str(obj.unViewedLeafCount))
                                 else:
                                     mli.setProperty('unwatched', '1')
+
+                        mli.setProperty('progress', util.getProgressImage(obj))
                     else:
                         mli.clear()
                         if obj is False:

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -26,6 +26,9 @@ from lib import metadata
 from lib.util import T
 from lib.windows.home import MOVE_SET
 
+import time
+import re
+
 VIDEO_RELOAD_KW = dict(includeExtras=1, includeExtrasCount=10, includeChapters=1)
 
 
@@ -547,11 +550,16 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
         self.setProperty('unavailable', not self.video.media()[0].isAccessible() and '1' or '')
 
+        remainingTime = None
         if self.video.viewOffset.asInt():
             width = self.video.viewOffset.asInt() and (1 + int((self.video.viewOffset.asInt() / self.video.duration.asFloat()) * self.width)) or 1
             self.progressImageControl.setWidth(width)
+            remainingTime = time.strftime("%Hh %Mm left", time.gmtime((self.video.duration.asInt() - self.video.viewOffset.asInt()) / 1000))
+            remainingTime = re.sub(r'0(\d[hm])', r'\1', remainingTime).replace('0h ', '').replace(' 0m', '')
         else:
             self.progressImageControl.setWidth(1)
+
+        self.setProperty('remainingTime', remainingTime)
 
     def setAudioAndSubtitleInfo(self):
         sas = self.video.selectedAudioStream()

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -429,17 +429,22 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
         resume = False
         if self.video.viewOffset.asInt():
-            button = optionsdialog.show(
-                T(32314, 'In Progress'),
-                T(32315, 'Resume playback?'),
-                T(32316, 'Resume'),
-                T(32317, 'Play From Beginning')
+            choice = dropdown.showDropdown(
+                options=[
+                    {'key': 'resume', 'display': T(32429, 'Resume from {0}').format(util.timeDisplay(self.video.viewOffset.asInt()).lstrip('0').lstrip(':'))},
+                    {'key': 'play', 'display': T(32317, 'Play from beginning')}
+                ],
+                pos=(660, 441),
+                close_direction='none',
+                set_dropdown_prop=False,
+                header=T(32314, 'In Progress')
             )
 
-            if button is None:
+            if not choice:
                 return
 
-            resume = (button == 0)
+            if choice['key'] == 'resume':
+                resume = True
 
         self.processCommand(videoplayer.play(video=self.video, resume=resume))
         return True

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import os
 
 from kodi_six import xbmc
 from kodi_six import xbmcgui
@@ -19,12 +18,10 @@ from . import pagination
 
 from plexnet import plexplayer, media
 
-from lib import colors
 from lib import util
 from lib import metadata
 
 from lib.util import T
-from lib.windows.home import MOVE_SET
 
 import time
 import re
@@ -487,6 +484,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.setProperty('title', self.video.title)
         self.setProperty('duration', util.durationToText(self.video.duration.asInt()))
         self.setProperty('summary', self.video.summary.strip().replace('\t', ' '))
+        self.setProperty('unwatched', not self.video.isWatched and '1' or '')
 
         directors = u' / '.join([d.tag for d in self.video.directors()][:5])
         directorsLabel = len(self.video.directors) > 1 and T(32401, u'DIRECTORS').upper() or T(32383, u'DIRECTOR').upper()

--- a/resources/skins/Main/1080i/script-plex-episodes.xml
+++ b/resources/skins/Main/1080i/script-plex-episodes.xml
@@ -159,16 +159,40 @@
                     </control>
                 </control>
 
-                <control type="label">
+                <control type="grouplist">
                     <posx>776</posx>
                     <posy>0</posy>
                     <width>1360</width>
                     <height>60</height>
-                    <font>font16</font>
                     <align>left</align>
-                    <aligny>top</aligny>
-                    <textcolor>FFFFFFFF</textcolor>
-                    <label>$INFO[Container(400).ListItem.Property(title)]</label>
+                    <itemgap>0</itemgap>
+                    <orientation>horizontal</orientation>
+                    <usecontrolcoords>true</usecontrolcoords>
+                    <control type="label">
+                        <width>auto</width>
+                        <height>60</height>
+                        <font>font16</font>
+                        <align>left</align>
+                        <aligny>top</aligny>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <label>$INFO[Container(400).ListItem.Property(title)]</label>
+                    </control>
+                    <control type="button">
+                        <visible>!String.IsEmpty(Container(400).ListItem.Property(remainingTime))</visible>
+                        <posx>10</posx>
+                        <posy>6</posy>
+                        <width>auto</width>
+                        <height>34</height>
+                        <font>font12</font>
+                        <align>center</align>
+                        <aligny>center</aligny>
+                        <focusedcolor>FFE5A00D</focusedcolor>
+                        <textcolor>FFE5A00D</textcolor>
+                        <textoffsetx>15</textoffsetx>
+                        <texturefocus colordiffuse="40000000" border="12">script.plex/white-square-rounded.png</texturefocus>
+                        <texturenofocus colordiffuse="40000000" border="12">script.plex/white-square-rounded.png</texturenofocus>
+                        <label>$INFO[Container(400).ListItem.Property(remainingTime)]</label>
+                    </control>
                 </control>
                 <control type="label">
                     <posx>776</posx>

--- a/resources/skins/Main/1080i/script-plex-pre_play.xml
+++ b/resources/skins/Main/1080i/script-plex-pre_play.xml
@@ -199,15 +199,39 @@
                         <aspectratio>scale</aspectratio>
                     </control>
                 </control>
-                <control type="label">
+                <control type="grouplist">
                     <posx>466</posx>
                     <posy>0</posy>
                     <width>1360</width>
                     <height>60</height>
-                    <font>font30</font>
                     <align>left</align>
-                    <textcolor>FFFFFFFF</textcolor>
-                    <label>$INFO[Window.Property(title)]</label>
+                    <itemgap>0</itemgap>
+                    <orientation>horizontal</orientation>
+                    <usecontrolcoords>true</usecontrolcoords>
+                    <control type="label">
+                        <width>auto</width>
+                        <height>60</height>
+                        <font>font30</font>
+                        <align>left</align>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <label>$INFO[Window.Property(title)]</label>
+                    </control>
+                    <control type="button">
+                        <visible>!String.IsEmpty(Window.Property(remainingTime))</visible>
+                        <posx>10</posx>
+                        <posy>6</posy>
+                        <width>auto</width>
+                        <height>34</height>
+                        <font>font12</font>
+                        <align>center</align>
+                        <aligny>center</aligny>
+                        <focusedcolor>FFE5A00D</focusedcolor>
+                        <textcolor>FFE5A00D</textcolor>
+                        <textoffsetx>15</textoffsetx>
+                        <texturefocus colordiffuse="40000000" border="8">script.plex/white-square-rounded-top-padded.png</texturefocus>
+                        <texturenofocus colordiffuse="40000000" border="8">script.plex/white-square-rounded-top-padded.png</texturenofocus>
+                        <label>$INFO[Window.Property(remainingTime)]</label>
+                    </control>
                 </control>
                 <control type="grouplist">
                     <posx>466</posx>

--- a/resources/skins/Main/1080i/script-plex-pre_play.xml
+++ b/resources/skins/Main/1080i/script-plex-pre_play.xml
@@ -159,6 +159,14 @@
                         <texture background="true">$INFO[Window.Property(thumb)]</texture>
                         <aspectratio>scale</aspectratio>
                     </control>
+                    <control type="image">
+                        <visible>!String.IsEmpty(Window.Property(unwatched))</visible>
+                        <posx>359</posx>
+                        <posy>0</posy>
+                        <width>48</width>
+                        <height>48</height>
+                        <texture>script.plex/indicators/unwatched.png</texture>
+                    </control>
                 </control>
 
                 <control type="group">


### PR DESCRIPTION
- Change resume dialog to show resume time
- Add unwatched status to pre-play screen and add progress bars to more hubs
- Fix missing parameters on Plex API queries 
- Add time left to pre-play screen 
- Fix audio/subtitle selection not updating correctly in pre-play screen