### PR TITLE
Strip out MP4 file name in stream URL to prevent subtitles trying to be downloaded

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -874,7 +874,7 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
         # Kodi 19 will try to look for subtitles in the directory containing the file. '/' and `/file.mkv` both point
         # to the file, and Kodi will happily try to read the whole file without recognizing it isn't a directory.
         # To get around that, we omit the filename here since it is unnecessary.
-        url = meta.streamUrls[0].replace("file.mkv", "")
+        url = meta.streamUrls[0].replace("file.mkv", "").replace("file.mp4", "")
 
         bifURL = self.playerObject.getBifUrl()
         util.DEBUG_LOG('Playing URL(+{1}ms): {0}{2}'.format(plexnetUtil.cleanToken(url), offset, bifURL and ' - indexed' or ''))


### PR DESCRIPTION
Having issues with MP4 files taking forever to load. This fixes the issue