### PR TITLE
Support custom library layout via xml file

### DIFF
--- a/customlayout.xml
+++ b/customlayout.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Copy this file into the userdata/addon_data/script.zidooplexmod/ directory.  You can customize the
+layout for each server and user by specifying a section for every user in you Plex server or you can
+setup a 'default' user so that every user who doesn't have a specific layout will use that default
+layout.  If a 'default' section isn't provided and a user doesn't have it's own section then
+ZidooPlexMod will pick the order.
+Arrange the libraries in the order that you want them shown on the title bar.  Anything you don't
+put into this list will be displayed at the end.  If you want to hide a library then add "hide" to
+the xml entry.  You can add or remove as many users/libraries as necessary to accommodate your Plex
+server.
+-->
+<custom_layout>
+    <server name="plex server name 1">
+        <user name="default">
+            <library name="library 1"></library>
+            <library name="library 2"></library>
+            <library name="Playlists">hide</library>
+        </user>
+        <user name="plex username 1">
+            <library name="library 1"></library>
+            <library name="library 2">hide</library>
+            <library name="Playlists">hide</library>
+        </user>
+        <user name="plex username 2">
+            <library name="library 1"></library>
+            <library name="library 2">hide</library>
+            <library name="Playlists"></library>
+        </user>
+    </server>
+    <server name="plex server name 2">
+        <user name="default">
+            <library name="library 1"></library>
+            <library name="library 2"></library>
+            <library name="Playlists">hide</library>
+        </user>
+        <user name="plex username 1">
+            <library name="library 1">hide</library>
+            <library name="library 2"></library>
+            <library name="Playlists">hide</library>
+        </user>
+    </server>
+</custom_layout>

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -3,7 +3,7 @@ import time
 import threading
 import re
 
-from kodi_six import xbmc
+from kodi_six import xbmc, xbmcvfs
 from kodi_six import xbmcgui
 
 from . import kodigui
@@ -24,6 +24,8 @@ from . import optionsdialog
 
 from lib.util import T
 from six.moves import range
+
+import xml.etree.ElementTree as ET
 
 
 HUBS_REFRESH_INTERVAL = 300  # 5 Minutes
@@ -382,6 +384,14 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         )
 
         self.hubFocusIndexes = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 13, 14, 15, 23)
+
+        try:
+            tree = ET.parse(xbmcvfs.translatePath(util.ADDON.getAddonInfo('profile') + 'customlayout.xml'))
+            self.customLayout = tree.getroot()
+            util.DEBUG_LOG(f'Zidoo: Custom layout found')
+        except:
+            self.customLayout = None
+            util.DEBUG_LOG(f'Zidoo: No custom layout')
 
         self.bottomItem = 0
         if self.serverRefresh():
@@ -810,11 +820,12 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         items.append(homemli)
 
         pl = plexapp.SERVERMANAGER.selectedServer.playlists()
+        plli = None
         if pl:
             plli = kodigui.ManagedListItem('Playlists', thumbnailImage='script.plex/home/type/playlists.png', data_source=PlaylistsSection)
             plli.setProperty('is.playlists', '1')
             plli.setProperty('item', '1')
-            items.append(plli)
+            # Don't add it yet in case they customized things
 
         try:
             sections = plexapp.SERVERMANAGER.selectedServer.library.sections()
@@ -826,6 +837,49 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         if plexapp.SERVERMANAGER.selectedServer.hasHubs():
             self.tasks = [SectionHubsTask().setup(s, self.sectionHubsCallback) for s in [HomeSection, PlaylistsSection] + sections]
             backgroundthread.BGThreader.addTasks(self.tasks)
+
+        if self.customLayout:
+            serverName = (plexapp.SERVERMANAGER.selectedServer.name or ' ').lower()
+            selectedServer = None
+            for server in self.customLayout.findall('server'):
+                curServerName = (server.get('name') or ' ').lower()
+                if curServerName == serverName:
+                    selectedServer = server
+                    break
+
+            if selectedServer:
+                userName = (plexapp.ACCOUNT.title or plexapp.ACCOUNT.username or ' ').lower()
+                selectedUser = None
+                for user in selectedServer.findall('user'):
+                    curUserName = (user.get('name') or ' ').lower()
+                    if curUserName == 'default':
+                        selectedUser = user
+                        continue
+                    elif curUserName == userName:
+                        selectedUser = user
+                        break
+
+                if selectedUser:
+                    for library in selectedUser.findall('library'):
+                        util.DEBUG_LOG(f"Zidoo: CL - {library.get('name')} - {library.text}")
+                        libraryName = (library.get('name') or ' ').lower()
+                        if libraryName == 'playlists' and plli:
+                            if not library.text or library.text.lower() != 'hide':
+                                items.append(plli)
+                            plli = None
+                        else:
+                            for index, section in enumerate(sections):
+                                if (section.title or ' ').lower() == libraryName:
+                                    if not library.text or library.text.lower() != 'hide':
+                                        mli = kodigui.ManagedListItem(section.title, thumbnailImage='script.plex/home/type/{0}.png'.format(section.type), data_source=section)
+                                        mli.setProperty('item', '1')
+                                        items.append(mli)
+                                    sections.remove(section)
+                                    break
+
+        # Add anything else that the user didn't customize
+        if plli:
+            items.append(plli)
 
         for section in sections:
             mli = kodigui.ManagedListItem(section.title, thumbnailImage='script.plex/home/type/{0}.png'.format(section.type), data_source=section)


### PR DESCRIPTION
Not sure if you want this change or not but I've got a somewhat crude way to customize the home screen libraries.  There is an xml file where you can define which libraries to show and in what order.  This can be customized for different users and different plex servers.  I saw someone asking about this capability in the Plex forum so thought I'd post it in case you want to pull it in.