### PR TITLE
Add settings option to stops post-play timer with ok button

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -116,7 +116,8 @@ class AdvancedSettings(object):
         ("requests_timeout", 5.0),
         ("local_reach_timeout", 10),
         ("auto_skip_offset", 2.5),
-        ("conn_check_timeout", 2.5)
+        ("conn_check_timeout", 2.5),
+        ("cancel_post_play_timer_with_ok_button", False)
     )
 
     def __init__(self):

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -202,7 +202,7 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         elif controlID == self.PREV_BUTTON_ID:
             self.playVideo(prev=True)
         elif controlID == self.NEXT_BUTTON_ID:
-            if not timeoutCanceled:
+            if not util.advancedSettings.cancelPostPlayTimerWithOkButton or not timeoutCanceled:
                 self.playVideo()
         elif controlID == self.PLAYER_STATUS_BUTTON_ID:
             self.showAudioPlayer()

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1134,6 +1134,10 @@ msgctxt "#32543"
 msgid "Ends at"
 msgstr ""
 
+msgctxt "#32544"
+msgid "Cancel the post play timer by hitting the ok/select button"
+msgstr ""
+
 msgctxt "#32601"
 msgid "Allow AV1"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -165,6 +165,12 @@
                         <dependency type="enable" setting="show_media_ends_info">true</dependency>
                     </dependencies>
                 </setting>
+                <setting id="cancel_post_play_timer_with_ok_button" type="boolean" label="32544" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                    <visible>true</visible>
+                </setting>
             </group>
         </category>
         <category id="user_interface" label="32467">


### PR DESCRIPTION
Most post-play timer count down screens allow you to just click ok/select to go to the next video so it seems like that should be the default.  This gives the user a setting to change that behavior so that it cancels the timer when clicking the ok/select.