### PR TITLE
Episode progress and time remaining not updating

### DIFF
--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -1074,6 +1074,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin, playbackse
                 if with_progress:
                     self.episodesPaginator.prepareListItem(None, mli)
                 if mli == selected:
+                    self.lastItem = mli
                     self.setProgress(mli)
                 return
 


### PR DESCRIPTION
- On the episodes screen if you have the cursor in the episode list and select an episode to play when you come back the "last item" isn't updated.  So if you watch episode 1 and then go to episode 2 in the post play screen, when you come back from episode 2 the "last item" field will still be set to 1.  So if you move the cursor back to episode 1 it won't re-fetch the progress because it thinks it was already the selected episode.