### PR TITLE
Fix hub refresh so it only requests one update

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -964,6 +964,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
         if time.time() - hubs.lastUpdated > HUBS_REFRESH_INTERVAL:
             util.DEBUG_LOG('Section is stale: REFRESHING - update: {0}'.format(update))
+            hubs.lastUpdated = time.time()
             self.cleanTasks()
             if not update:
                 if section.key in self.sectionHubs:


### PR DESCRIPTION
- If the hub refresh interval was triggered I would see multiple(3-5) different hub refreshes requested by the tick() function before the hubs.lastUpdated was set by the background task.  This will update the lastUpdated time right away so that only one update is triggered

## Checklist:
- [X] I have based this PR against the develop branch
