### PR TITLE
Move actor images on episodes and seasons screens

### DIFF
--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -189,9 +189,9 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMix
 
     EPISODE_LIST_ID = 400
     SEASONS_LIST_ID = 401
-    EXTRA_LIST_ID = 402
-    RELATED_LIST_ID = 403
-    ROLES_LIST_ID = 404
+    ROLES_LIST_ID = 402
+    EXTRA_LIST_ID = 403
+    RELATED_LIST_ID = 404
 
     OPTIONS_GROUP_ID = 200
 
@@ -259,10 +259,10 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMix
         self.episodeListControl = kodigui.ManagedControlList(self, self.EPISODE_LIST_ID, 5)
         self.progressImageControl = self.getControl(self.PROGRESS_IMAGE_ID)
 
+        self.seasonsListControl = kodigui.ManagedControlList(self, self.SEASONS_LIST_ID, 5)
+        self.rolesListControl = kodigui.ManagedControlList(self, self.ROLES_LIST_ID, 5)
         self.extraListControl = kodigui.ManagedControlList(self, self.EXTRA_LIST_ID, 5)
         self.relatedListControl = kodigui.ManagedControlList(self, self.RELATED_LIST_ID, 5)
-        self.rolesListControl = kodigui.ManagedControlList(self, self.ROLES_LIST_ID, 5)
-        self.seasonsListControl = kodigui.ManagedControlList(self, self.SEASONS_LIST_ID, 5)
 
         self._setup()
         self.postSetup()
@@ -487,12 +487,12 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMix
                 self.openItem(self.seasonsListControl, came_from=self.season.parentRatingKey)
             else:
                 self.setFocusId(self.EPISODE_LIST_ID)
+        elif controlID == self.ROLES_LIST_ID:
+            self.roleClicked()
         elif controlID == self.EXTRA_LIST_ID:
             self.openItem(self.extraListControl)
         elif controlID == self.RELATED_LIST_ID:
             self.openItem(self.relatedListControl)
-        elif controlID == self.ROLES_LIST_ID:
-            self.roleClicked()
 
     def onFocus(self, controlID):
         self.lastFocusID = controlID
@@ -554,21 +554,17 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMix
     def getRoleItemDDPosition(self):
         y = 980
         if xbmc.getCondVisibility('Control.IsVisible(500)'):
-            y += 360
+            y += 380
         if xbmc.getCondVisibility('Control.IsVisible(501)'):
-            y += 520
-        if xbmc.getCondVisibility('Control.IsVisible(502)'):
-            y += 520
+            y += 420
         if xbmc.getCondVisibility('!String.IsEmpty(Window.Property(on.extras))'):
-            y -= 125
+            y -= 80
         if xbmc.getCondVisibility('Integer.IsGreater(Window.Property(hub.focus),0) + Control.IsVisible(500)'):
             y -= 500
         if xbmc.getCondVisibility('Integer.IsGreater(Window.Property(hub.focus),1) + Control.IsVisible(501)'):
             y -= 500
-        if xbmc.getCondVisibility('Integer.IsGreater(Window.Property(hub.focus),1) + Control.IsVisible(502)'):
-            y -= 500
 
-        focus = int(xbmc.getInfoLabel('Container(403).Position'))
+        focus = int(xbmc.getInfoLabel('Container(402).Position'))
 
         x = ((focus + 1) * 304) - 100
         return x, y

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -49,9 +49,9 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMixin, 
 
     SUB_ITEM_LIST_ID = 400
 
-    EXTRA_LIST_ID = 401
-    RELATED_LIST_ID = 402
-    ROLES_LIST_ID = 403
+    ROLES_LIST_ID = 401
+    EXTRA_LIST_ID = 402
+    RELATED_LIST_ID = 403
 
     OPTIONS_GROUP_ID = 200
 
@@ -84,9 +84,10 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMixin, 
 
     def onFirstInit(self):
         self.subItemListControl = kodigui.ManagedControlList(self, self.SUB_ITEM_LIST_ID, 5)
+        self.rolesListControl = kodigui.ManagedControlList(self, self.ROLES_LIST_ID, 5)
         self.extraListControl = kodigui.ManagedControlList(self, self.EXTRA_LIST_ID, 5)
         self.relatedListControl = kodigui.ManagedControlList(self, self.RELATED_LIST_ID, 5)
-        self.rolesListControl = kodigui.ManagedControlList(self, self.ROLES_LIST_ID, 5)
+
         self.progressImageControl = self.getControl(self.PROGRESS_IMAGE_ID)
 
         self.setup()
@@ -500,21 +501,13 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMixin, 
     def getRoleItemDDPosition(self):
         y = 980
         if xbmc.getCondVisibility('Control.IsVisible(500)'):
-            y += 360
-        if xbmc.getCondVisibility('Control.IsVisible(501)'):
-            y += 360
-        if xbmc.getCondVisibility('Control.IsVisible(502)'):
-            y += 520
+            y += 380
         if xbmc.getCondVisibility('!String.IsEmpty(Window.Property(on.extras))'):
-            y -= 300
+            y -= 200
         if xbmc.getCondVisibility('Integer.IsGreater(Window.Property(hub.focus),0) + Control.IsVisible(500)'):
             y -= 500
-        if xbmc.getCondVisibility('Integer.IsGreater(Window.Property(hub.focus),1) + Control.IsVisible(501)'):
-            y -= 360
-        if xbmc.getCondVisibility('Integer.IsGreater(Window.Property(hub.focus),1) + Control.IsVisible(502)'):
-            y -= 500
 
-        focus = int(xbmc.getInfoLabel('Container(403).Position'))
+        focus = int(xbmc.getInfoLabel('Container(401).Position'))
 
         x = ((focus + 1) * 304) - 100
         return x, y

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1657,3 +1657,7 @@ msgstr ""
 msgctxt "#32962"
 msgid "Visually separate hubs horizontally using a thin line."
 msgstr ""
+
+msgctxt "#32963"
+msgid "Seasons"
+msgstr ""

--- a/resources/skins/Main/1080i/script-plex-episodes.xml
+++ b/resources/skins/Main/1080i/script-plex-episodes.xml
@@ -536,18 +536,11 @@
                 <onup>300</onup>
                 <itemgap>0</itemgap>
 
+                <!-- EPISODES -->
                 <control type="group" id="500">
                     <visible>Integer.IsGreater(Container(400).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
                     <height>360</height>
                     <width>1920</width>
-                    <control type="image">
-                        <posx>0</posx>
-                        <posy>0</posy>
-                        <width>1920</width>
-                        <height>360</height>
-                        <texture>script.plex/white-square.png</texture>
-                        <colordiffuse>40000000</colordiffuse>
-                    </control>
                     <control type="label">
                         <posx>60</posx>
                         <posy>0</posy>
@@ -563,7 +556,7 @@
                         <posx>0</posx>
                         <posy>18</posy>
                         <width>1920</width>
-                        <height>430</height>
+                        <height>360</height>
                         <onup>300</onup>
                         <ondown>401</ondown>
                         <onleft>false</onleft>
@@ -848,15 +841,16 @@
                         </focusedlayout>
                     </control>
                 </control>
+                <!-- EPISODES -->
 
                 <!-- Seasons -->
                 <control type="group" id="501">
                     <visible>Integer.IsGreater(Container(401).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
-                    <height>400</height>
+                    <height>380</height>
                     <width>1920</width>
                     <control type="label">
                         <posx>60</posx>
-                        <posy>20</posy>
+                        <posy>0</posy>
                         <width>800</width>
                         <height>40</height>
                         <font>font12</font>
@@ -867,9 +861,9 @@
                     </control>
                     <control type="list" id="401">
                         <posx>0</posx>
-                        <posy>50</posy>
+                        <posy>36</posy>
                         <width>1920</width>
-                        <height>360</height>
+                        <height>380</height>
                         <onup>400</onup>
                         <ondown>402</ondown>
                         <scrolltime>200</scrolltime>
@@ -1034,20 +1028,171 @@
                         </focusedlayout>
                     </control>
                 </control>
+                <!-- Seasons -->
 
+                <!-- ROLES -->
                 <control type="group" id="502">
                     <visible>Integer.IsGreater(Container(402).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+                    <defaultcontrol>402</defaultcontrol>
+                    <width>1920</width>
+                    <height>400</height>
+                    <control type="label">
+                        <posx>60</posx>
+                        <posy>-20</posy>
+                        <width>1000</width>
+                        <height>80</height>
+                        <font>font12</font>
+                        <align>left</align>
+                        <aligny>center</aligny>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <label>[UPPERCASE]$ADDON[script.plexmod 32419][/UPPERCASE]</label>
+                    </control>
+                    <control type="list" id="402">
+                        <posx>0</posx>
+                        <posy>0</posy>
+                        <width>1920</width>
+                        <height>400</height>
+                        <onup>401</onup>
+                        <ondown>403</ondown>
+                        <scrolltime>200</scrolltime>
+                        <orientation>horizontal</orientation>
+                        <preloaditems>4</preloaditems>
+                        <!-- ITEM LAYOUT ########################################## -->
+                        <itemlayout width="304">
+                            <control type="group">
+                                <posx>55</posx>
+                                <posy>61</posy>
+                                <control type="group">
+                                    <posx>5</posx>
+                                    <posy>5</posy>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>244</width>
+                                        <height>244</height>
+                                        <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
+                                    </control>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>244</width>
+                                        <height>244</height>
+                                        <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
+                                        <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
+                                    </control>
+                                    <control type="group">
+                                        <posx>0</posx>
+                                        <posy>253</posy>
+                                        <control type="label">
+                                            <scroll>false</scroll>
+                                            <posx>0</posx>
+                                            <posy>0</posy>
+                                            <width>244</width>
+                                            <height>60</height>
+                                            <font>font10</font>
+                                            <align>center</align>
+                                            <textcolor>AAFFFFFF</textcolor>
+                                            <label>$INFO[ListItem.Label]</label>
+                                        </control>
+                                        <control type="label">
+                                            <scroll>false</scroll>
+                                            <posx>0</posx>
+                                            <posy>30</posy>
+                                            <width>244</width>
+                                            <height>60</height>
+                                            <font>font10</font>
+                                            <align>center</align>
+                                            <textcolor>AAFFFFFF</textcolor>
+                                            <label>$INFO[ListItem.Label2]</label>
+                                        </control>
+                                    </control>
+                                </control>
+                            </control>
+                        </itemlayout>
+
+                        <!-- FOCUSED LAYOUT ####################################### -->
+                        <focusedlayout width="304">
+                            <control type="group">
+                                <posx>55</posx>
+                                <posy>61</posy>
+                                <control type="group">
+                                    <animation effect="zoom" start="100" end="110" time="100" center="127,127" reversible="false">Focus</animation>
+                                    <animation effect="zoom" start="110" end="100" time="100" center="127,127" reversible="false">UnFocus</animation>
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <control type="image">
+                                        <visible>Control.HasFocus(402)</visible>
+                                        <posx>-40</posx>
+                                        <posy>-40</posy>
+                                        <width>334</width>
+                                        <height>334</height>
+                                        <texture border="42">script.plex/buttons/role-shadow.png</texture>
+                                    </control>
+                                    <control type="group">
+                                        <posx>5</posx>
+                                        <posy>5</posy>
+                                        <control type="image">
+                                            <posx>0</posx>
+                                            <posy>0</posy>
+                                            <width>244</width>
+                                            <height>244</height>
+                                            <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
+                                        </control>
+                                        <control type="image">
+                                            <posx>0</posx>
+                                            <posy>0</posy>
+                                            <width>244</width>
+                                            <height>244</height>
+                                            <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
+                                            <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
+                                        </control>
+                                        <control type="group">
+                                            <posx>0</posx>
+                                            <posy>253</posy>
+                                            <control type="label">
+                                                <scroll>Control.HasFocus(402)</scroll>
+                                                <posx>0</posx>
+                                                <posy>0</posy>
+                                                <width>244</width>
+                                                <height>60</height>
+                                                <font>font10</font>
+                                                <align>center</align>
+                                                <textcolor>AAFFFFFF</textcolor>
+                                                <label>$INFO[ListItem.Label]</label>
+                                            </control>
+                                            <control type="label">
+                                                <scroll>Control.HasFocus(402)</scroll>
+                                                <posx>0</posx>
+                                                <posy>30</posy>
+                                                <width>244</width>
+                                                <height>60</height>
+                                                <font>font10</font>
+                                                <align>center</align>
+                                                <textcolor>AAFFFFFF</textcolor>
+                                                <label>$INFO[ListItem.Label2]</label>
+                                            </control>
+                                        </control>
+                                    </control>
+                                    <control type="image">
+                                        <visible>Control.HasFocus(402)</visible>
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>254</width>
+                                        <height>254</height>
+                                        <texture>script.plex/buttons/role-selected.png</texture>
+                                    </control>
+                                </control>
+                            </control>
+                        </focusedlayout>
+                    </control>
+                </control>
+                <!-- ROLES -->
+
+                <!-- EXTRAS -->
+                <control type="group" id="503">
+                    <visible>Integer.IsGreater(Container(403).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
                     <height>360</height>
                     <width>1920</width>
-                    <control type="image">
-                        <visible>!String.IsEmpty(Window.Property(divider.402))</visible>
-                        <posx>60</posx>
-                        <posy>0</posy>
-                        <width>1800</width>
-                        <height>2</height>
-                        <texture>script.plex/white-square.png</texture>
-                        <colordiffuse>A0000000</colordiffuse>
-                    </control>
                     <control type="label">
                         <posx>60</posx>
                         <posy>0</posy>
@@ -1059,13 +1204,13 @@
                         <textcolor>AAFFFFFF</textcolor>
                         <label>[UPPERCASE]$INFO[Window.Property(extras.header)][/UPPERCASE]</label>
                     </control>
-                    <control type="list" id="402">
+                    <control type="list" id="403">
                         <posx>0</posx>
                         <posy>18</posy>
                         <width>1920</width>
                         <height>430</height>
-                        <onup>401</onup>
-                        <ondown>403</ondown>
+                        <onup>402</onup>
+                        <ondown>404</ondown>
                         <scrolltime>200</scrolltime>
                         <orientation>horizontal</orientation>
                         <preloaditems>4</preloaditems>
@@ -1130,7 +1275,7 @@
                                     <posx>0</posx>
                                     <posy>0</posy>
                                     <control type="image">
-                                        <visible>Control.HasFocus(402)</visible>
+                                        <visible>Control.HasFocus(403)</visible>
                                         <posx>-40</posx>
                                         <posy>-40</posy>
                                         <width>389</width>
@@ -1158,7 +1303,7 @@
                                         </control>
                                         <control type="group">
                                             <control type="label">
-                                                <scroll>Control.HasFocus(402)</scroll>
+                                                <scroll>Control.HasFocus(403)</scroll>
                                                 <posx>0</posx>
                                                 <posy>175</posy>
                                                 <width>299</width>
@@ -1169,7 +1314,7 @@
                                                 <label>$INFO[ListItem.Label]</label>
                                             </control>
                                             <control type="label">
-                                                <scroll>Control.HasFocus(402)</scroll>
+                                                <scroll>Control.HasFocus(403)</scroll>
                                                 <posx>0</posx>
                                                 <posy>205</posy>
                                                 <width>299</width>
@@ -1182,7 +1327,7 @@
                                         </control>
                                     </control>
                                     <control type="image">
-                                        <visible>Control.HasFocus(402)</visible>
+                                        <visible>Control.HasFocus(403)</visible>
                                         <posx>0</posx>
                                         <posy>0</posy>
                                         <width>309</width>
@@ -1194,21 +1339,14 @@
                         </focusedlayout>
                     </control>
                 </control>
+                <!-- EXTRAS -->
 
-                <control type="group" id="503">
-                    <visible>Integer.IsGreater(Container(403).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
-                    <defaultcontrol>402</defaultcontrol>
+                <!-- RELATED -->
+                <control type="group" id="504">
+                    <visible>Integer.IsGreater(Container(404).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+                    <defaultcontrol>404</defaultcontrol>
                     <width>1920</width>
                     <height>520</height>
-                    <control type="image">
-                        <visible>!String.IsEmpty(Window.Property(divider.403))</visible>
-                        <posx>60</posx>
-                        <posy>0</posy>
-                        <width>1800</width>
-                        <height>2</height>
-                        <texture>script.plex/white-square.png</texture>
-                        <colordiffuse>A0000000</colordiffuse>
-                    </control>
                     <control type="label">
                         <posx>60</posx>
                         <posy>0</posy>
@@ -1220,12 +1358,12 @@
                         <textcolor>FFFFFFFF</textcolor>
                         <label>[UPPERCASE]$INFO[Window.Property(related.header)][/UPPERCASE]</label>
                     </control>
-                    <control type="list" id="403">
+                    <control type="list" id="404">
                         <posx>0</posx>
                         <posy>16</posy>
                         <width>1920</width>
                         <height>520</height>
-                        <onup>402</onup>
+                        <onup>403</onup>
                         <ondown>404</ondown>
                         <onleft>false</onleft>
                         <onright>false</onright>
@@ -1408,7 +1546,7 @@
                                         </control>
                                     </control>
                                     <control type="image">
-                                        <visible>Control.HasFocus(403)</visible>
+                                        <visible>Control.HasFocus(404)</visible>
                                         <posx>-40</posx>
                                         <posy>-40</posy>
                                         <width>324</width>
@@ -1493,7 +1631,7 @@
                                             </control>
                                         </control>
                                         <control type="label">
-                                            <scroll>Control.HasFocus(403)</scroll>
+                                            <scroll>Control.HasFocus(404)</scroll>
                                             <posx>0</posx>
                                             <posy>369</posy>
                                             <width>244</width>
@@ -1505,7 +1643,7 @@
                                         </control>
                                     </control>
                                     <control type="image">
-                                        <visible>Control.HasFocus(403)</visible>
+                                        <visible>Control.HasFocus(404)</visible>
                                         <posx>0</posx>
                                         <posy>0</posy>
                                         <width>254</width>
@@ -1517,171 +1655,8 @@
                         </focusedlayout>
                     </control>
                 </control>
+                <!-- RELATED -->
 
-                <control type="group" id="504">
-                    <visible>Integer.IsGreater(Container(404).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
-                    <defaultcontrol>403</defaultcontrol>
-                    <width>1920</width>
-                    <height>410</height>
-                    <control type="image">
-                        <visible>!String.IsEmpty(Window.Property(divider.404))</visible>
-                        <posx>60</posx>
-                        <posy>20</posy>
-                        <width>1800</width>
-                        <height>2</height>
-                        <texture>script.plex/white-square.png</texture>
-                        <colordiffuse>A0000000</colordiffuse>
-                    </control>
-                    <control type="label">
-                        <posx>60</posx>
-                        <posy>20</posy>
-                        <width>1000</width>
-                        <height>80</height>
-                        <font>font12</font>
-                        <align>left</align>
-                        <aligny>center</aligny>
-                        <textcolor>FFFFFFFF</textcolor>
-                        <label>[UPPERCASE]$ADDON[script.plexmod 32419][/UPPERCASE]</label>
-                    </control>
-                    <control type="list" id="404">
-                        <posx>0</posx>
-                        <posy>36</posy>
-                        <width>1920</width>
-                        <height>410</height>
-                        <onup>403</onup>
-                        <ondown>404</ondown>
-                        <scrolltime>200</scrolltime>
-                        <orientation>horizontal</orientation>
-                        <preloaditems>4</preloaditems>
-                        <!-- ITEM LAYOUT ########################################## -->
-                        <itemlayout width="304">
-                            <control type="group">
-                               <posx>55</posx>
-                                <posy>61</posy>
-                                <control type="group">
-                                    <posx>5</posx>
-                                    <posy>5</posy>
-                                    <control type="image">
-                                        <posx>0</posx>
-                                        <posy>0</posy>
-                                        <width>244</width>
-                                        <height>244</height>
-                                        <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
-                                    </control>
-                                    <control type="image">
-                                        <posx>0</posx>
-                                        <posy>0</posy>
-                                        <width>244</width>
-                                        <height>244</height>
-                                        <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
-                                        <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
-                                    </control>
-                                    <control type="group">
-                                        <posx>0</posx>
-                                        <posy>253</posy>
-                                        <control type="label">
-                                            <scroll>false</scroll>
-                                            <posx>0</posx>
-                                            <posy>0</posy>
-                                            <width>244</width>
-                                            <height>60</height>
-                                            <font>font10</font>
-                                            <align>center</align>
-                                            <textcolor>AAFFFFFF</textcolor>
-                                            <label>$INFO[ListItem.Label]</label>
-                                        </control>
-                                        <control type="label">
-                                            <scroll>false</scroll>
-                                            <posx>0</posx>
-                                            <posy>30</posy>
-                                            <width>244</width>
-                                            <height>60</height>
-                                            <font>font10</font>
-                                            <align>center</align>
-                                            <textcolor>AAFFFFFF</textcolor>
-                                            <label>$INFO[ListItem.Label2]</label>
-                                        </control>
-                                    </control>
-                                </control>
-                            </control>
-                        </itemlayout>
-
-                        <!-- FOCUSED LAYOUT ####################################### -->
-                        <focusedlayout width="304">
-                            <control type="group">
-                                <posx>55</posx>
-                                <posy>61</posy>
-                                <control type="group">
-                                    <animation effect="zoom" start="100" end="110" time="100" center="127,127" reversible="false">Focus</animation>
-                                    <animation effect="zoom" start="110" end="100" time="100" center="127,127" reversible="false">UnFocus</animation>
-                                    <posx>0</posx>
-                                    <posy>0</posy>
-                                    <control type="image">
-                                        <visible>Control.HasFocus(404)</visible>
-                                        <posx>-40</posx>
-                                        <posy>-40</posy>
-                                        <width>334</width>
-                                        <height>334</height>
-                                        <texture border="42">script.plex/buttons/role-shadow.png</texture>
-                                    </control>
-                                    <control type="group">
-                                        <posx>5</posx>
-                                        <posy>5</posy>
-                                        <control type="image">
-                                            <posx>0</posx>
-                                            <posy>0</posy>
-                                            <width>244</width>
-                                            <height>244</height>
-                                            <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
-                                        </control>
-                                        <control type="image">
-                                            <posx>0</posx>
-                                            <posy>0</posy>
-                                            <width>244</width>
-                                            <height>244</height>
-                                            <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
-                                            <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
-                                        </control>
-                                        <control type="group">
-                                            <posx>0</posx>
-                                            <posy>253</posy>
-                                            <control type="label">
-                                                <scroll>Control.HasFocus(404)</scroll>
-                                                <posx>0</posx>
-                                                <posy>0</posy>
-                                                <width>244</width>
-                                                <height>60</height>
-                                                <font>font10</font>
-                                                <align>center</align>
-                                                <textcolor>AAFFFFFF</textcolor>
-                                                <label>$INFO[ListItem.Label]</label>
-                                            </control>
-                                            <control type="label">
-                                                <scroll>Control.HasFocus(404)</scroll>
-                                                <posx>0</posx>
-                                                <posy>30</posy>
-                                                <width>244</width>
-                                                <height>60</height>
-                                                <font>font10</font>
-                                                <align>center</align>
-                                                <textcolor>AAFFFFFF</textcolor>
-                                                <label>$INFO[ListItem.Label2]</label>
-                                            </control>
-                                        </control>
-                                    </control>
-                                    <control type="image">
-                                        <visible>Control.HasFocus(404)</visible>
-                                        <posx>0</posx>
-                                        <posy>0</posy>
-                                        <width>254</width>
-                                        <height>254</height>
-                                        <texture>script.plex/buttons/role-selected.png</texture>
-                                    </control>
-                                </control>
-                            </control>
-                        </focusedlayout>
-                    </control>
-                </control>
             </control>
         </control>
 

--- a/resources/skins/Main/1080i/script-plex-seasons.xml
+++ b/resources/skins/Main/1080i/script-plex-seasons.xml
@@ -368,23 +368,27 @@
                 <onup>300</onup>
                 <itemgap>0</itemgap>
 
+                <!-- Seasons -->
                 <control type="group" id="500">
                     <visible>Integer.IsGreater(Container(400).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
-                    <height>360</height>
+                    <height>380</height>
                     <width>1920</width>
-                    <control type="image">
-                        <posx>0</posx>
+                    <control type="label">
+                        <posx>60</posx>
                         <posy>0</posy>
-                        <width>1920</width>
-                        <height>360</height>
-                        <texture>script.plex/white-square.png</texture>
-                        <colordiffuse>40000000</colordiffuse>
+                        <width>800</width>
+                        <height>40</height>
+                        <font>font12</font>
+                        <align>left</align>
+                        <aligny>center</aligny>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <label>[UPPERCASE]$ADDON[script.plexmod 32963][/UPPERCASE]</label>
                     </control>
                     <control type="list" id="400">
                         <posx>0</posx>
-                        <posy>14</posy>
+                        <posy>36</posy>
                         <width>1920</width>
-                        <height>430</height>
+                        <height>380</height>
                         <onup>300</onup>
                         <ondown>401</ondown>
                         <scrolltime>200</scrolltime>
@@ -549,9 +553,169 @@
                         </focusedlayout>
                     </control>
                 </control>
+                <!-- Seasons -->
 
+                <!-- ROLES -->
                 <control type="group" id="501">
                     <visible>Integer.IsGreater(Container(401).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+                    <defaultcontrol>401</defaultcontrol>
+                    <width>1920</width>
+                    <height>400</height>
+                    <control type="label">
+                        <posx>60</posx>
+                        <posy>-20</posy>
+                        <width>1000</width>
+                        <height>80</height>
+                        <font>font12</font>
+                        <align>left</align>
+                        <aligny>center</aligny>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <label>[UPPERCASE]$ADDON[script.plexmod 32419][/UPPERCASE]</label>
+                    </control>
+                    <control type="list" id="401">
+                        <posx>0</posx>
+                        <posy>0</posy>
+                        <width>1920</width>
+                        <height>400</height>
+                        <onup>400</onup>
+                        <ondown>402</ondown>
+                        <scrolltime>200</scrolltime>
+                        <orientation>horizontal</orientation>
+                        <preloaditems>4</preloaditems>
+                        <!-- ITEM LAYOUT ########################################## -->
+                        <itemlayout width="304">
+                            <control type="group">
+                                <posx>55</posx>
+                                <posy>61</posy>
+                                <control type="group">
+                                    <posx>5</posx>
+                                    <posy>5</posy>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>244</width>
+                                        <height>244</height>
+                                        <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
+                                    </control>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>244</width>
+                                        <height>244</height>
+                                        <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
+                                        <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
+                                    </control>
+                                    <control type="group">
+                                        <posx>0</posx>
+                                        <posy>253</posy>
+                                        <control type="label">
+                                            <scroll>false</scroll>
+                                            <posx>0</posx>
+                                            <posy>0</posy>
+                                            <width>244</width>
+                                            <height>60</height>
+                                            <font>font10</font>
+                                            <align>center</align>
+                                            <textcolor>AAFFFFFF</textcolor>
+                                            <label>$INFO[ListItem.Label]</label>
+                                        </control>
+                                        <control type="label">
+                                            <scroll>false</scroll>
+                                            <posx>0</posx>
+                                            <posy>30</posy>
+                                            <width>244</width>
+                                            <height>60</height>
+                                            <font>font10</font>
+                                            <align>center</align>
+                                            <textcolor>AAFFFFFF</textcolor>
+                                            <label>$INFO[ListItem.Label2]</label>
+                                        </control>
+                                    </control>
+                                </control>
+                            </control>
+                        </itemlayout>
+
+                        <!-- FOCUSED LAYOUT ####################################### -->
+                        <focusedlayout width="304">
+                            <control type="group">
+                                <posx>55</posx>
+                                <posy>61</posy>
+                                <control type="group">
+                                    <animation effect="zoom" start="100" end="110" time="100" center="127,127" reversible="false">Focus</animation>
+                                    <animation effect="zoom" start="110" end="100" time="100" center="127,127" reversible="false">UnFocus</animation>
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <control type="image">
+                                        <visible>Control.HasFocus(401)</visible>
+                                        <posx>-40</posx>
+                                        <posy>-40</posy>
+                                        <width>334</width>
+                                        <height>334</height>
+                                        <texture border="42">script.plex/buttons/role-shadow.png</texture>
+                                    </control>
+                                    <control type="group">
+                                        <posx>5</posx>
+                                        <posy>5</posy>
+                                        <control type="image">
+                                            <posx>0</posx>
+                                            <posy>0</posy>
+                                            <width>244</width>
+                                            <height>244</height>
+                                            <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
+                                        </control>
+                                        <control type="image">
+                                            <posx>0</posx>
+                                            <posy>0</posy>
+                                            <width>244</width>
+                                            <height>244</height>
+                                            <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
+                                            <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
+                                        </control>
+                                        <control type="group">
+                                            <posx>0</posx>
+                                            <posy>253</posy>
+                                            <control type="label">
+                                                <scroll>Control.HasFocus(401)</scroll>
+                                                <posx>0</posx>
+                                                <posy>0</posy>
+                                                <width>244</width>
+                                                <height>60</height>
+                                                <font>font10</font>
+                                                <align>center</align>
+                                                <textcolor>AAFFFFFF</textcolor>
+                                                <label>$INFO[ListItem.Label]</label>
+                                            </control>
+                                            <control type="label">
+                                                <scroll>Control.HasFocus(401)</scroll>
+                                                <posx>0</posx>
+                                                <posy>30</posy>
+                                                <width>244</width>
+                                                <height>60</height>
+                                                <font>font10</font>
+                                                <align>center</align>
+                                                <textcolor>AAFFFFFF</textcolor>
+                                                <label>$INFO[ListItem.Label2]</label>
+                                            </control>
+                                        </control>
+                                    </control>
+                                    <control type="image">
+                                        <visible>Control.HasFocus(401)</visible>
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>254</width>
+                                        <height>254</height>
+                                        <texture>script.plex/buttons/role-selected.png</texture>
+                                    </control>
+                                </control>
+                            </control>
+                        </focusedlayout>
+                    </control>
+                </control>
+                <!-- ROLES -->
+
+                <!-- EXTRAS -->
+                <control type="group" id="502">
+                    <visible>Integer.IsGreater(Container(402).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
                     <height>360</height>
                     <width>1920</width>
                     <control type="label">
@@ -565,13 +729,13 @@
                         <textcolor>FFFFFFFF</textcolor>
                         <label>[UPPERCASE]$INFO[Window.Property(extras.header)][/UPPERCASE]</label>
                     </control>
-                    <control type="list" id="401">
+                    <control type="list" id="402">
                         <posx>0</posx>
                         <posy>18</posy>
                         <width>1920</width>
                         <height>430</height>
-                        <onup>400</onup>
-                        <ondown>402</ondown>
+                        <onup>401</onup>
+                        <ondown>403</ondown>
                         <scrolltime>200</scrolltime>
                         <orientation>horizontal</orientation>
                         <preloaditems>4</preloaditems>
@@ -636,7 +800,7 @@
                                     <posx>0</posx>
                                     <posy>0</posy>
                                     <control type="image">
-                                        <visible>Control.HasFocus(401)</visible>
+                                        <visible>Control.HasFocus(402)</visible>
                                         <posx>-40</posx>
                                         <posy>-40</posy>
                                         <width>389</width>
@@ -664,7 +828,7 @@
                                         </control>
                                         <control type="group">
                                             <control type="label">
-                                                <scroll>Control.HasFocus(401)</scroll>
+                                                <scroll>Control.HasFocus(402)</scroll>
                                                 <posx>0</posx>
                                                 <posy>175</posy>
                                                 <width>299</width>
@@ -675,7 +839,7 @@
                                                 <label>$INFO[ListItem.Label]</label>
                                             </control>
                                             <control type="label">
-                                                <scroll>Control.HasFocus(401)</scroll>
+                                                <scroll>Control.HasFocus(402)</scroll>
                                                 <posx>0</posx>
                                                 <posy>210</posy>
                                                 <width>299</width>
@@ -688,7 +852,7 @@
                                         </control>
                                     </control>
                                     <control type="image">
-                                        <visible>Control.HasFocus(401)</visible>
+                                        <visible>Control.HasFocus(402)</visible>
                                         <posx>0</posx>
                                         <posy>0</posy>
                                         <width>309</width>
@@ -700,14 +864,16 @@
                         </focusedlayout>
                     </control>
                 </control>
+                <!-- EXTRAS -->
 
-                <control type="group" id="502">
-                    <visible>Integer.IsGreater(Container(402).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
-                    <defaultcontrol>402</defaultcontrol>
+                <!-- RELATED -->
+                <control type="group" id="503">
+                    <visible>Integer.IsGreater(Container(403).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+                    <defaultcontrol>403</defaultcontrol>
                     <width>1920</width>
                     <height>520</height>
                     <control type="image">
-                        <visible>!String.IsEmpty(Window.Property(divider.402))</visible>
+                        <visible>!String.IsEmpty(Window.Property(divider.403))</visible>
                         <posx>60</posx>
                         <posy>0</posy>
                         <width>1800</width>
@@ -726,12 +892,12 @@
                         <textcolor>FFFFFFFF</textcolor>
                         <label>[UPPERCASE]$INFO[Window.Property(related.header)][/UPPERCASE]</label>
                     </control>
-                    <control type="list" id="402">
+                    <control type="list" id="403">
                         <posx>0</posx>
                         <posy>16</posy>
                         <width>1920</width>
                         <height>520</height>
-                        <onup>401</onup>
+                        <onup>402</onup>
                         <ondown>403</ondown>
                         <onleft>false</onleft>
                         <onright>false</onright>
@@ -880,7 +1046,7 @@
                                     <posx>0</posx>
                                     <posy>0</posy>
                                     <control type="image">
-                                        <visible>Control.HasFocus(402)</visible>
+                                        <visible>Control.HasFocus(403)</visible>
                                         <posx>-40</posx>
                                         <posy>-40</posy>
                                         <width>324</width>
@@ -965,7 +1131,7 @@
                                             </control>
                                         </control>
                                         <control type="label">
-                                            <scroll>Control.HasFocus(402)</scroll>
+                                            <scroll>Control.HasFocus(403)</scroll>
                                             <posx>0</posx>
                                             <posy>369</posy>
                                             <width>244</width>
@@ -977,7 +1143,7 @@
                                         </control>
                                     </control>
                                     <control type="image">
-                                        <visible>Control.HasFocus(402)</visible>
+                                        <visible>Control.HasFocus(403)</visible>
                                         <posx>0</posx>
                                         <posy>0</posy>
                                         <width>254</width>
@@ -1023,171 +1189,8 @@
                         </focusedlayout>
                     </control>
                 </control>
+                <!-- RELATED -->
 
-                <control type="group" id="503">
-                    <visible>Integer.IsGreater(Container(403).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
-                    <defaultcontrol>403</defaultcontrol>
-                    <width>1920</width>
-                    <height>410</height>
-                    <control type="image">
-                        <visible>!String.IsEmpty(Window.Property(divider.403))</visible>
-                        <posx>60</posx>
-                        <posy>20</posy>
-                        <width>1800</width>
-                        <height>2</height>
-                        <texture>script.plex/white-square.png</texture>
-                        <colordiffuse>A0000000</colordiffuse>
-                    </control>
-                    <control type="label">
-                        <posx>60</posx>
-                        <posy>20</posy>
-                        <width>1000</width>
-                        <height>80</height>
-                        <font>font12</font>
-                        <align>left</align>
-                        <aligny>center</aligny>
-                        <textcolor>FFFFFFFF</textcolor>
-                        <label>[UPPERCASE]$ADDON[script.plexmod 32419][/UPPERCASE]</label>
-                    </control>
-                    <control type="list" id="403">
-                        <posx>0</posx>
-                        <posy>36</posy>
-                        <width>1920</width>
-                        <height>410</height>
-                        <onup>402</onup>
-                        <ondown>403</ondown>
-                        <scrolltime>200</scrolltime>
-                        <orientation>horizontal</orientation>
-                        <preloaditems>4</preloaditems>
-                        <!-- ITEM LAYOUT ########################################## -->
-                        <itemlayout width="304">
-                            <control type="group">
-                               <posx>55</posx>
-                                <posy>61</posy>
-                                <control type="group">
-                                    <posx>5</posx>
-                                    <posy>5</posy>
-                                    <control type="image">
-                                        <posx>0</posx>
-                                        <posy>0</posy>
-                                        <width>244</width>
-                                        <height>244</height>
-                                        <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
-                                    </control>
-                                    <control type="image">
-                                        <posx>0</posx>
-                                        <posy>0</posy>
-                                        <width>244</width>
-                                        <height>244</height>
-                                        <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
-                                        <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
-                                    </control>
-                                    <control type="group">
-                                        <posx>0</posx>
-                                        <posy>253</posy>
-                                        <control type="label">
-                                            <scroll>false</scroll>
-                                            <posx>0</posx>
-                                            <posy>0</posy>
-                                            <width>244</width>
-                                            <height>60</height>
-                                            <font>font10</font>
-                                            <align>center</align>
-                                            <textcolor>AAFFFFFF</textcolor>
-                                            <label>$INFO[ListItem.Label]</label>
-                                        </control>
-                                        <control type="label">
-                                            <scroll>false</scroll>
-                                            <posx>0</posx>
-                                            <posy>30</posy>
-                                            <width>244</width>
-                                            <height>60</height>
-                                            <font>font10</font>
-                                            <align>center</align>
-                                            <textcolor>AAFFFFFF</textcolor>
-                                            <label>$INFO[ListItem.Label2]</label>
-                                        </control>
-                                    </control>
-                                </control>
-                            </control>
-                        </itemlayout>
-
-                        <!-- FOCUSED LAYOUT ####################################### -->
-                        <focusedlayout width="304">
-                            <control type="group">
-                                <posx>55</posx>
-                                <posy>61</posy>
-                                <control type="group">
-                                    <animation effect="zoom" start="100" end="110" time="100" center="127,127" reversible="false">Focus</animation>
-                                    <animation effect="zoom" start="110" end="100" time="100" center="127,127" reversible="false">UnFocus</animation>
-                                    <posx>0</posx>
-                                    <posy>0</posy>
-                                    <control type="image">
-                                        <visible>Control.HasFocus(403)</visible>
-                                        <posx>-40</posx>
-                                        <posy>-40</posy>
-                                        <width>334</width>
-                                        <height>334</height>
-                                        <texture border="42">script.plex/buttons/role-shadow.png</texture>
-                                    </control>
-                                    <control type="group">
-                                        <posx>5</posx>
-                                        <posy>5</posy>
-                                        <control type="image">
-                                            <posx>0</posx>
-                                            <posy>0</posy>
-                                            <width>244</width>
-                                            <height>244</height>
-                                            <texture diffuse="script.plex/masks/role.png">script.plex/thumb_fallbacks/role.png</texture>
-                                        </control>
-                                        <control type="image">
-                                            <posx>0</posx>
-                                            <posy>0</posy>
-                                            <width>244</width>
-                                            <height>244</height>
-                                            <texture background="true" diffuse="script.plex/masks/role.png">$INFO[ListItem.Thumb]</texture>
-                                            <aspectratio scalediffuse="false" aligny="top">scale</aspectratio>
-                                        </control>
-                                        <control type="group">
-                                            <posx>0</posx>
-                                            <posy>253</posy>
-                                            <control type="label">
-                                                <scroll>Control.HasFocus(403)</scroll>
-                                                <posx>0</posx>
-                                                <posy>0</posy>
-                                                <width>244</width>
-                                                <height>60</height>
-                                                <font>font10</font>
-                                                <align>center</align>
-                                                <textcolor>AAFFFFFF</textcolor>
-                                                <label>$INFO[ListItem.Label]</label>
-                                            </control>
-                                            <control type="label">
-                                                <scroll>Control.HasFocus(403)</scroll>
-                                                <posx>0</posx>
-                                                <posy>30</posy>
-                                                <width>244</width>
-                                                <height>60</height>
-                                                <font>font10</font>
-                                                <align>center</align>
-                                                <textcolor>AAFFFFFF</textcolor>
-                                                <label>$INFO[ListItem.Label2]</label>
-                                            </control>
-                                        </control>
-                                    </control>
-                                    <control type="image">
-                                        <visible>Control.HasFocus(403)</visible>
-                                        <posx>0</posx>
-                                        <posy>0</posy>
-                                        <width>254</width>
-                                        <height>254</height>
-                                        <texture>script.plex/buttons/role-selected.png</texture>
-                                    </control>
-                                </control>
-                            </control>
-                        </focusedlayout>
-                    </control>
-                </control>
             </control>
         </control>
 


### PR DESCRIPTION
GHI (If applicable): #

## Description:
I've been working on this for a while now and clearly I'm not a GUI developer :) but thought I'd upload these changes as a starting base.  After you moved the actor images on the pre-play screen based on the plex web client I figured we should probably do the same thing for the seasons and episodes screens.  So this is my attempt at that.  But some of the calculations to figure out where the drop down box should go seemed really arbitrary so I just kind of fiddled until something worked.  Maybe you have a better understanding of how those numbers were picked in the first place.  When seasons are displayed(on the seasons screen or episodes screen) I tried to get the actor image and name/character name to show up on the screen while the seasons hub was selected.  This may not be the best for spacing but I thought it was nice to see those values without having to fully go to the "role" hub.  If other's don't like that I'm not married to the idea and I can work on adding the spacing back.

Seasons screen:
![Screenshot_20240109-114623](https://github.com/pannal/plex-for-kodi/assets/17151296/94b998cc-b5d5-4818-8b37-f2e871ca3d27)

Episodes screen with other seasons available:
![Screenshot_20240109-114640](https://github.com/pannal/plex-for-kodi/assets/17151296/a8881e2b-2def-45b7-92fe-9933e72d4400)

Episodes screen with no other seasons available:
![Screenshot_20240109-114607](https://github.com/pannal/plex-for-kodi/assets/17151296/3e96bd80-d56a-430f-9b29-443b058afdb1)


## Checklist:
- [X] I have based this PR against the develop branch
