### PR TITLE
Fixes for collections and filters

### DIFF
--- a/lib/_included_packages/plexnet/plexlibrary.py
+++ b/lib/_included_packages/plexnet/plexlibrary.py
@@ -154,7 +154,7 @@ class LibrarySection(plexobjects.PlexObject):
 
     def items(self, path, start, size, filter_, sort, unwatched, type_, tag_fallback):
 
-        args = {"includeCollections" : "1"}
+        args = {}
 
         if size is not None:
             args['X-Plex-Container-Start'] = start
@@ -162,6 +162,8 @@ class LibrarySection(plexobjects.PlexObject):
 
         if filter_:
             args[filter_[0]] = filter_[1]
+        else:
+            args['includeCollections'] = 1
 
         if sort:
             args['sort'] = '{0}:{1}'.format(*sort)
@@ -183,10 +185,12 @@ class LibrarySection(plexobjects.PlexObject):
         else:
             path = '/library/sections/{0}/firstCharacter'.format(self.key)
 
-        args = {"includeCollections" : "1"}
+        args = {}
 
         if filter_:
             args[filter_[0]] = filter_[1]
+        else:
+            args['includeCollections'] = 1
 
         if sort:
             args['sort'] = '{0}:{1}'.format(*sort)

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -1170,7 +1170,7 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
 
         options = []
 
-        if self.section.TYPE in ('movie', 'show'):
+        if self.section.TYPE in ('movie', 'show') and not ITEM_TYPE == 'collection':
             options.append({'type': 'unwatched', 'display': T(32368, 'UNPLAYED').upper(), 'indicator': self.filterUnwatched and check or ''})
 
         if self.filter:
@@ -1202,8 +1202,11 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
         }
 
         if self.section.TYPE == 'movie':
-            for k in ('year', 'decade', 'genre', 'contentRating', 'collection', 'director', 'actor', 'country', 'studio', 'resolution', 'labels'):
-                options.append(optionsMap[k])
+            if ITEM_TYPE == 'collection':
+                options.append(optionsMap['contentRating'])
+            else:
+                for k in ('year', 'decade', 'genre', 'contentRating', 'collection', 'director', 'actor', 'country', 'studio', 'resolution', 'labels'):
+                    options.append(optionsMap[k])
         elif self.section.TYPE == 'show':
             if ITEM_TYPE == 'episode':
                 for k in ('year', 'collection', 'resolution'):


### PR DESCRIPTION
- In the collections view most of the filters don't work so I've removed all but the content rating filter since that's the only one that seems to work
- In the movies view most of the filters will ignore the includeCollections option on the plex server request.  However, the content rating filter will include collections.  The problem is that the plex server query for the letter map doesn't.  So we end up with errors and not all of the media shown.  So I removed the includeCollections option from the queries where a filter is used. The plex app and plex web don't show collections on filters so PM4K will now behave the same way.

GHI (If applicable): #

## Description:

## Checklist:
- [X] I have based this PR against the develop branch
