### PR TITLE
Fix small poster display for Arial fonts

### DIFF
--- a/resources/skins/Main/1080i/script-plex-posters-small.xml
+++ b/resources/skins/Main/1080i/script-plex-posters-small.xml
@@ -434,7 +434,7 @@
                                         <posx>0</posx>
                                         <posy>218</posy>
                                         <width>144</width>
-                                        <height>30</height>
+                                        <height>20</height>
                                         <font>font10</font>
                                         <align>center</align>
                                         <textcolor>FFFFFFFF</textcolor>


### PR DESCRIPTION
GHI (If applicable): # N/A

## Description:

- If you're using the Arial fonts on the default skin the second line shows up on TV episodes when it should be hidden like the default font which is larger.

Before:
![Screenshot_20240518-154540](https://github.com/pannal/plex-for-kodi/assets/17151296/4ce2f867-f44e-45e8-a012-588ea7d547ab)

After:
![Screenshot_20240518-154147](https://github.com/pannal/plex-for-kodi/assets/17151296/4f6ad0f0-d81b-4ec9-b625-bcd90f66f24a)

## Checklist:
- [X] I have based this PR against the develop branch
