### PR TITLE
Set max_retries=1 for HTTP/HTTPS adapters

### DIFF
--- a/lib/_included_packages/plexnet/asyncadapter.py
+++ b/lib/_included_packages/plexnet/asyncadapter.py
@@ -336,8 +336,8 @@ class AsyncHTTPAdapter(HTTPAdapter):
 class Session(requests.Session):
     def __init__(self, *args, **kwargs):
         requests.Session.__init__(self, *args, **kwargs)
-        self.mount('https://', AsyncHTTPAdapter())
-        self.mount('http://', AsyncHTTPAdapter())
+        self.mount('https://', AsyncHTTPAdapter(max_retries=1))
+        self.mount('http://', AsyncHTTPAdapter(max_retries=1))
 
     def cancel(self):
         for v in self.adapters.values():


### PR DESCRIPTION
## Description:
After restoring from the hibernated state, all previously established TCP connections are being reset. As a result, the section refresh triggered by the `system.wakeup` listener fails, so the user have to switch to some other section in order to see any content. Allowing retries fixes this problem.

## Checklist:
- [x] I have based this PR against the develop branch
