### PR TITLE
Fix seek issue on Ugoos am6b+

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -12,6 +12,7 @@ import time
 import datetime
 import contextlib
 import types
+import subprocess
 
 import unicodedata
 
@@ -953,6 +954,27 @@ def getPlatform():
     ]:
         if xbmc.getCondVisibility(key):
             return key.rsplit('.', 1)[-1]
+
+
+# There are lots of different devices and different ways to get the device model.  This way is known
+# to work with the Ugoos am6b+ device but probably doesn't work for others.
+def getDeviceModel():
+    try:
+        deviceModel = "Unknown"
+        if(getPlatform() == "RaspberryPi"):
+            stdout = subprocess.check_output('cat /proc/cpuinfo', shell=True).decode()
+            hardwareRegex = re.compile(r'Hardware\s*:\s*(.*)')
+            match = hardwareRegex.search(stdout)
+            deviceModel = "Unknown"
+            if match:
+                deviceModel = match.group(1)
+
+        return deviceModel
+    except:
+        return "Unknown"
+
+
+deviceModel = getDeviceModel()
 
 
 def getRunningAddons():


### PR DESCRIPTION
GHI (If applicable): #

## Description:  
On the Ugoos am6b+ after seeking it can take 2-15 seconds for audio to start while the video is playing.  Playing the same file using the default kodi player does not exhibit this issue.  Changing to use the executebuiltin(Seek) solves this issue.  Hopefully this doesn't break other things because the player.seekTime is doing something else in the background that the executebuiltin doesn't.

## Checklist:
- [X] I have based this PR against the develop branch
