### PR TITLE
Fix issue with time fields not updating in OSD.

### DIFF
--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -1926,7 +1926,7 @@ class SeekDialog(kodigui.BaseDialog):
         self.killTimeKeeper()
 
     def syncTimeKeeper(self):
-        if not not self.handler.player.playerObject:
+        if not self.handler.player.playerObject:
             return
 
         self.timeKeeperTime = self.trueOffset()#int(self.handler.player.getTime() * 1000)


### PR DESCRIPTION
GHI (If applicable): #
N/A

## Description:
For transcoded streams the time on the OSD wasn't getting updated.  Small bug that prevented the time sync function from getting started.

## Checklist:
- [X] I have based this PR against the develop branch
