### PR TITLE
Fix issue on CoreELEC where selecting new audio stream causes video to start over.

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -440,6 +440,8 @@ class SeekPlayerHandler(BasePlayerHandler):
         self.player.trigger('started.video')
 
         if self.isDirectPlay:
+            if util.isCoreELEC:
+                xbmc.sleep(500)
             self.seekAbsolute()
 
         if self.dialog:


### PR DESCRIPTION
GHI (If applicable): #
N/A

## Description:
There is a timing issue after the video is restarted with the new audio stream. The seek back to the spot where the audio stream was changed is being ignored by Kodi. Adding in a delay before issuing the seek fixes the issue.

## Checklist:
- [X] I have based this PR against the develop branch
