### PR TITLE
Fix issue on CoreELEC where selecting new audio stream causes audio to stutter or delay

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -618,7 +618,7 @@ class SeekPlayerHandler(BasePlayerHandler):
                                self.player.getTime())
 
                 tries = 0
-                while self.player.getTime() * 1000 < withinSOS and tries < 50:
+                while self.player.isPlayingVideo() and self.player.getTime() * 1000 < withinSOS and tries < 50:
                     util.DEBUG_LOG("OnPlayBackSeek: SeekOnStart: Not there, yet, "
                                    "seeking again ({}, {})", self.seekOnStart, self.player.getTime())
                     self.dialog.offset = self.seekOnStart


### PR DESCRIPTION
GHI (If applicable): #
N/A

## Description:
When selecting a new audio stream CoreELEC devices may stutter or have the audio delayed for a while.  This attempts to fix that by pausing the video, issuing a seek, and finally starting the video up again.  The amount of time it's paused isn't really perceptible by the user.

## Checklist:
- [X] I have based this PR against the develop branch
