### PR TITLE
Fix folder view ITEM_TYPE not being retained after hitting back button

### DIFF
--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -1060,7 +1060,7 @@ class LibraryWindow(mixins.PlaybackBtnMixin, kodigui.MultiWindow, windowutils.Ut
         updateUnwatchedAndProgress = False
 
         if mli.dataSource.TYPE == 'collection':
-            prevItemType = self.librarySettings.getItemType()
+            prevItemType = self.librarySettings.getItemType() or ITEM_TYPE
             self.processCommand(opener.open(mli.dataSource))
             self.librarySettings.setItemType(prevItemType)
         elif self.section.TYPE == 'show' or mli.dataSource.TYPE == 'show' or mli.dataSource.TYPE == 'season' or mli.dataSource.TYPE == 'episode':
@@ -1084,7 +1084,7 @@ class LibraryWindow(mixins.PlaybackBtnMixin, kodigui.MultiWindow, windowutils.Ut
                 section.title = datasource.title
 
                 self.processCommand(opener.handleOpen(LibraryWindow, windows=self._windows, default_window=self._next, section=section, filter_=self.filter, subDir=True))
-                self.librarySettings.setItemType(self.librarySettings.getItemType())
+                self.librarySettings.setItemType(self.librarySettings.getItemType() or ITEM_TYPE)
             else:
                 self.processCommand(opener.handleOpen(preplay.PrePlayWindow, video=datasource, parent_list=self.showPanelControl))
                 updateUnwatchedAndProgress = True
@@ -1232,6 +1232,8 @@ class LibraryWindow(mixins.PlaybackBtnMixin, kodigui.MultiWindow, windowutils.Ut
                     self.setBoolProperty('no.content.filtered', True)
                 else:
                     self.setBoolProperty('no.content', True)
+
+                return
             else:
                 for startPosition in range(0, totalSize, self.getDefChunkSize(totalSize)):
                     tasks.append(CreateDefaultItemsTask().setup(startPosition, self.getDefChunkSize(totalSize), totalSize, self.thumb_fallback, self._defaultItemsCallback))


### PR DESCRIPTION
GHI (If applicable): #179

## Description:
I noticed sometimes on hitting the back button the ITEM_TYPE value was being reset.  Not sure if this is the same issue as #179 but the logs looked similar.  You can tell something is wrong because the HTTPS request as an odd "/all" in it.

https://192-168-0-93.32e879c23d4b44d0bcd075e0dd506cc1.plex.direct:32400/library/sections/2/folder?parent=2067/all&includeCollections=1&sort=titleSort%3Aasc&X-Plex-Container-Size=0&X-Plex-Container-Start=0&X-Plex-Token=****

I was seeing this locally when I would hit the back button after navigating to a folder without any content in it.  The ITEM_TYPE was getting wiped out so it then lost track of the fact that we were in folder view and would try and add the "/all" to the folder query.

## Checklist:
- [X] I have based this PR against the develop branch
