### PR TITLE
Updater Support For Custom Respositories

### DIFF
--- a/default.py
+++ b/default.py
@@ -7,7 +7,8 @@ import sys
 from lib.logging import log, KodiLogProxyHandler
 # noinspection PyUnresolvedReferences
 from lib.kodi_util import translatePath, xbmc, xbmcgui
-from lib.properties import getGlobalProperty, setGlobalProperty
+from lib.properties import getGlobalProperty, setGlobalProperty, setGlobalBoolProperty
+from lib.util import forced_update_check
 from tendo_singleton import SingleInstance, SingleInstanceException
 
 
@@ -99,6 +100,7 @@ try:
                             # no immediate start requested
                             main.util.MONITOR.waitForAbort(0.5)
 
+                setGlobalBoolProperty('force_update', forced_update_check())
                 setGlobalProperty('waiting_for_start', '', wait=True)
                 setGlobalProperty('started', '1', wait=True)
 

--- a/docs/Development/custom_repository.md
+++ b/docs/Development/custom_repository.md
@@ -1,0 +1,23 @@
+## Use
+Setting PM4K to use a custom repository may be useful in scenarios where the testing device is running a special OS (ex. CoreELEC) and you want to push updates to that device while using the same update mechanism used in PM4K.
+
+This is not intended for general use and is meant to be used by developers who want to contribute to the addon.
+
+## Setup
+Before you can use this, there's some code changes that need to be made. Fork the repository and make the following changes in your new fork:
+* Adjust the code in ```lib/updater/py```:
+    * (required) ```SHOW_CUSTOM_UPDATER_OPTION = False``` --> Set to ```True``` to enable the option of setting a custom repository
+    * (optional) ```CUSTOM_UPDATER_CHECK_IMMEDIATE = True``` --> Set to ```True``` to force an update check every time you open PM4K
+    * (required) ```CUSTOM_UPDATER_REPO = "pannal/plex-for-kodi"``` --> Replace ```pannal/plex-for-kodi``` with your username/repository
+    * (required) ```CUSTOM_UPDATER_BRANCH = "develop_kodi21"``` --> Replace ```develop_kodi21``` with the name of your branch
+
+Once you are done with that, download and install the new forked addon onto your machine. From here, change the following setting:
+* Settings -> System -> Update source -> Custom
+
+You can now push updates to your branch and every time you bump the version of the addon, PM4K will automatically try to pull an update on next run:
+* Adjust the code in ```addon.xml```:
+    * ```version="0.8.0-beta13.5"``` --> Bump the version up (ex. ```version="0.8.0-beta13.6"```)
+
+## Notes
+* If you disable ```SHOW_CUSTOM_UPDATER_OPTION``` and re-open PM4K, it will reset the 'Update source' setting back to default.
+* When submitting a pull request with new changes where this was used, make sure to reset the settings back to their default values (refer to the Setup section).

--- a/lib/main.py
+++ b/lib/main.py
@@ -26,6 +26,9 @@ from . import util
 from .logging import KodiLogProxyHandler
 from .data_cache import dcm
 
+from .updater import SHOW_CUSTOM_UPDATER_OPTION
+from .settings_util import getSetting, setSetting
+
 BACKGROUND = None
 quitKodi = False
 restart = False
@@ -115,6 +118,12 @@ def main(force_render=False):
 
 def _main():
     global quitKodi, restart
+
+    # Check if SHOW_CUSTOM_UPDATER_OPTION is set to false and update_source is set to "custom"
+    # If so, reset it back to its default value
+    if not SHOW_CUSTOM_UPDATER_OPTION and getSetting('update_source', 'repository') == 'custom':
+        setSetting('update_source', 'repository')
+        util.LOG('Custom updater is disabled but also selected, resetting to default')
 
     # uncomment to profile code #1
     #pr = cProfile.Profile()

--- a/lib/update_checker.py
+++ b/lib/update_checker.py
@@ -9,11 +9,12 @@ import lib.kodi_util
 # noinspection PyUnresolvedReferences
 from lib.kodi_util import xbmc, xbmcgui, xbmcaddon, ICON_PATH, KODI_VERSION_MAJOR
 from lib.settings_util import getSetting, setSetting
-from lib.properties import IPCTimeoutException, waitForGPEmpty, setGlobalProperty, getGlobalProperty
+from lib.properties import IPCTimeoutException, waitForGPEmpty, setGlobalProperty, getGlobalProperty, setGlobalBoolProperty
 from lib.updater import get_updater, UpdateException, UpdaterSkipException
 from lib.addonsettings import addonSettings
 from lib.i18n import T
 from lib.logging import service_log as log
+
 
 class ServiceMonitor(xbmc.Monitor):
     def __init__(self, *args, **kwargs):
@@ -71,6 +72,11 @@ def update_loop():
         if getSetting('last_update_check', datetime.datetime.fromtimestamp(0)) != last_update_check:
             setSetting('last_update_check', last_update_check)
 
+        # Check if a forced update is requested
+        if getGlobalProperty('force_update'):
+            log('Forced update detected, setting check_immediate to True')
+            check_immediate = True
+
         if (last_update_check + check_interval <= now or check_immediate) and not MONITOR.device_sleeping:
             if not any([
                     xbmc.Player().isPlaying(),
@@ -85,7 +91,10 @@ def update_loop():
                     if check_immediate:
                         check_immediate = False
 
-                    log('Checking for updates')
+                    log('Checking for updates' +
+                        (' (forced)' if getGlobalProperty('force_update') else '') +
+                        ', mode: {}'.format(mode) +
+                        (', repo: {}, branch: {}'.format(updater.repo, updater.branch) if mode == 'custom' else ''))
                     update_version = updater.check(addon_version, allow_downgrade=allow_downgrade)
                     log('Current: {}, Latest: {}, Update/Sidegrade/Downgrade: {}'.format(addon_version,
                                                                                          updater.remote_version,
@@ -219,6 +228,8 @@ def update_loop():
                     setGlobalProperty('update_response', '')
                     setGlobalProperty('update_source_changed', '')
                     setGlobalProperty('update_is_downgrade', '')
+                    if getGlobalProperty('force_update'):
+                        setGlobalBoolProperty('force_update', False)
                     # lel
                     try:
                         if pd:

--- a/lib/updater.py
+++ b/lib/updater.py
@@ -13,6 +13,11 @@ from .version import version_compare
 from .kodi_util import translatePath, xbmc, ADDON
 from .kodijsonrpc import rpc
 
+# Variables for custom repository and branch (must be updated here in the code)
+SHOW_CUSTOM_UPDATER_OPTION = False  # Control whether the "custom" option shows up in the update source setting
+CUSTOM_UPDATER_CHECK_IMMEDIATE = True  # Control whether we always want to immediately check for updates (requires 'update_source' to be set to custom)
+CUSTOM_UPDATER_REPO = "pannal/plex-for-kodi"  # Set the Github repo for the custom repository
+CUSTOM_UPDATER_BRANCH = "develop_kodi21"  # Set the branch for the custom repository
 
 VERSION_RE = re.compile(r'<addon id="script\.plexmod".*version="([A-Za-z0-9.+:~-]+)".*?<requires>',
                         re.MULTILINE | re.DOTALL | re.S)
@@ -247,6 +252,18 @@ class RepositoryUpdater(Updater):
         xbmc.executebuiltin('UpdateAddonRepos', True)
         xbmc.executebuiltin('UpdateLocalAddons', True)
         return False
+
+
+@register_updater
+class CustomUpdater(Updater):
+    mode = "custom"
+    repo = CUSTOM_UPDATER_REPO
+    branch = CUSTOM_UPDATER_BRANCH
+
+    def __init__(self, branch=CUSTOM_UPDATER_BRANCH, mode="custom"):
+        super(CustomUpdater, self).__init__(branch=branch, mode=mode)
+        self.repo = CUSTOM_UPDATER_REPO
+        self.branch = branch
 
 
 def get_updater(mode):

--- a/lib/util.py
+++ b/lib/util.py
@@ -40,6 +40,8 @@ from .addonsettings import addonSettings, AddonSettings
 from .settings_util import getSetting, getUserSetting, setSetting, USER_SETTINGS, JSON_SETTINGS, DEFAULT_SETTINGS
 from .monitor import MONITOR
 
+from lib.updater import CUSTOM_UPDATER_CHECK_IMMEDIATE
+
 
 DEBUG = True
 _SHUTDOWN = False
@@ -885,3 +887,7 @@ def shutdown():
     del MONITOR
     del T
     del ADDON
+
+def forced_update_check():
+    if getSetting('update_source', 'repository') == 'custom' and CUSTOM_UPDATER_CHECK_IMMEDIATE:
+        return True

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -18,6 +18,7 @@ import lib.cache
 from lib import util
 from lib import genres
 from lib import actions
+from lib.updater import SHOW_CUSTOM_UPDATER_OPTION
 from lib.util import T
 from . import kodigui
 from . import windowutils
@@ -912,12 +913,17 @@ class Settings(object):
                     'update_source',
                     T(33676, 'Update source'),
                     'repository',
-                    (('beta', T(33678, 'Beta')), ('stable', T(33679, 'Stable')),
-                     ('repository', T(33680, 'Repository')))
+                    (
+                        ('beta', T(33678, 'Beta')),
+                        ('stable', T(33679, 'Stable')),
+                        ('repository', T(33680, 'Repository')),
+                        (('custom', T(33055, 'Custom')) if SHOW_CUSTOM_UPDATER_OPTION else ('', ''))
+                    )
                 ).description(T(33677, 'Specifies the update mode. Will immediately check for a new version '
                                        'when changed and closing settings.\nDefault: Repository\n\nBeta: Bleeding '
                                        'edge (possibly unstable)\nStable: Stable branch (faster than Repository)\n'
-                                       'Repository: Kodi repository (official (slow) or Don\'t Panic)')
+                                       'Repository: Kodi repository (official (slow) or Don\'t Panic)') + 
+                                       T(34012, '\nCustom: Custom branch') if SHOW_CUSTOM_UPDATER_OPTION else ''
                               ) if not util.FROM_KODI_REPOSITORY else None,
                 MultiOptionsSetting(
                     'cache_requests', T(33724, 'Cache Plex data for'),
@@ -1206,7 +1212,8 @@ class SettingsWindow(kodigui.BaseWindow, windowutils.UtilMixin):
                 items.append(kodigui.ManagedListItem(label))
         elif setting.type in ('OPTIONS', 'MULTI'):
             for ID, label in setting.options:
-                items.append(kodigui.ManagedListItem(label, data_source=ID))
+                if ID and label:
+                    items.append(kodigui.ManagedListItem(label, data_source=ID))
 
         self.optionsList.reset()
         self.optionsList.addItems(items)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -2693,3 +2693,7 @@ msgstr ""
 msgctxt "#34011"
 msgid "Remove from watchlist"
 msgstr ""
+
+msgctxt "#34012"
+msgid "\nCustom: Custom branch"
+msgstr ""


### PR DESCRIPTION
GHI (If applicable): n/a

## Description:
Created a new feature to allow using a custom repository & branch as an update source, intending to be used by developers testing out code changes for their fork or branch using the same updater mechanism you have built.
- New option value in 'Update source' called 'Custom', only appears if custom sources is enabled in the code
- Updated description for 'Update source' to include a blurb for custom, only appears if custom sources is enabled in the code
- Repo and branch are updated in the code to choose where to pull from

I understand that we wouldn't want general users to accidentally enable this and end up with a broken updater or worse, so this is only available by code changes after the repository has been forked.

I have created a new folder called docs to store wiki pages and wrote a guide for using this for developers to reference, you can also see more detail of how this works. I am pretty unfamiliar with this part, so I am not sure if the structure for this is correct.

I am pretty new to addon development, pushing code to Github, and pretty unfamiliar with your code. I'm by no means a professional at programming (just do it as a hobby), but I tried to add my code within the same design pattern you already had.

I apologize if anything was done incorrectly, let me know and I am happy to take a look!

## Checklist:
- [ x] I have based this PR against the develop branch
