### PR TITLE
Fix template setup when the add on directory is not writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Master branch is based off of the official plex-for-kodi master branch.
 ### Manual
 * Checkout any branch of this GitHub repository, rename to `script.plexmod` and use as an addon
 
+### Installing to a read-only or write-protected location
+Set the environment variable `INSTALLATION_DIR_AVOID_WRITE` to any value before starting Kodi to prevent the addon from trying to write to its installation directory. Useful for package managers.
+
 ## Translation
 You can help! Join the translation effort at [POEditor](https://poeditor.com/join/project/ASOl50YAXg) (thanks for the free open source license, guys).
 

--- a/lib/_included_packages/plexnet/gdm.py
+++ b/lib/_included_packages/plexnet/gdm.py
@@ -28,7 +28,7 @@ class GDMDiscovery(object):
         from . import plexapp
         return util.INTERFACE.getPreference("gdm_discovery", True) and self.thread and self.thread.is_alive()
 
-    '''
+    r'''
     def discover(self):
         # Only allow discovery if enabled and not currently running
         self._close = False

--- a/lib/templating/core.py
+++ b/lib/templating/core.py
@@ -1,12 +1,14 @@
 # coding=utf-8
 import os
 import glob
+import shutil
 
 from pprint import pformat
 from kodi_six import xbmcvfs, xbmc
 from ibis.context import ContextDict
 from lib.logging import log as LOG, log_error as ERROR
 from .util import deep_update
+from ..util import PROFILE
 from lib.os_utils import fast_iglob
 from .filters import *
 
@@ -60,10 +62,25 @@ class TemplateEngine(object):
 
     def init(self, target_dir, template_dir, custom_template_dir):
         self.target_dir = target_dir
+        if not os.access(target_dir, os.W_OK):
+            # Use the user addon data directory in installations where the extension installation directory is not writable, for example when the addon is installed through the system package manager
+            # Redirect template write target_dir to writable addon_data
+            writable_base = os.path.join(PROFILE, "resources/skins/Main/1080i")
+            os.makedirs(writable_base, exist_ok=True)
+            # Link media dir into addon dir, so templates can access it via relative path
+            link_path = os.path.join(PROFILE, "resources/skins/Main/media")
+            media_src = os.path.join(os.path.dirname(target_dir), "media")
+            if not os.path.exists(link_path):
+                try:
+                    os.symlink(media_src, link_path, True)
+                except (OSError, NotImplementedError):
+                    # If symlink fails (eg on windows without admin access), copy instead
+                    shutil.copytree(media_src, link_path)
+            self.target_dir = writable_base
         self.template_dir = template_dir
         self.custom_template_dir = custom_template_dir
         self.get_available_templates()
-        paths = [custom_template_dir, template_dir]
+        paths = [custom_template_dir, self.template_dir]
 
         LOG("Looking for templates in: {}", paths)
         self.prepare_loader(paths)

--- a/lib/templating/core.py
+++ b/lib/templating/core.py
@@ -62,7 +62,11 @@ class TemplateEngine(object):
 
     def init(self, target_dir, template_dir, custom_template_dir):
         self.target_dir = target_dir
-        if not os.access(target_dir, os.W_OK):
+
+
+        # Alternative to checking env var: automatically set if dir isn't
+        # writable with `if not os.access(path, os.W_OK):`
+        if os.getenv("INSTALLATION_DIR_AVOID_WRITE"):
             # Use the user addon data directory in installations where the extension installation directory is not writable, for example when the addon is installed through the system package manager
             # Redirect template write target_dir to writable addon_data
             writable_base = os.path.join(PROFILE, "resources/skins/Main/1080i")

--- a/lib/windows/kodigui.py
+++ b/lib/windows/kodigui.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import threading
 import time
 import traceback
+import os
 
 from kodi_six import xbmc
 from kodi_six import xbmcgui
@@ -41,13 +42,21 @@ class BaseFunctions(object):
 
     @classmethod
     def open(cls, **kwargs):
-        window = cls(cls.xmlFile, cls.path, cls.theme, cls.res, **kwargs)
+        path = cls.path
+        if not os.access(path, os.W_OK):
+            path = util.PROFILE
+        window = cls(xmlFile=cls.xmlFile, path=path, theme=cls.theme, res=cls.res, **kwargs)
         window.modal()
         return window
 
     @classmethod
     def create(cls, show=True, **kwargs):
-        window = cls(cls.xmlFile, cls.path, cls.theme, cls.res, **kwargs)
+        # Use the user addon data directory in installations where the extension installation directory is not writable
+        path = cls.path
+        if not os.access(path, os.W_OK):
+            path = util.PROFILE
+        window = cls(xmlFile=cls.xmlFile, path=path, theme=cls.theme, res=cls.res, **kwargs)
+
         if show:
             window.show()
             if xbmcgui.getCurrentWindowId() < 13000:

--- a/lib/windows/kodigui.py
+++ b/lib/windows/kodigui.py
@@ -43,7 +43,7 @@ class BaseFunctions(object):
     @classmethod
     def open(cls, **kwargs):
         path = cls.path
-        if not os.access(path, os.W_OK):
+        if os.getenv("INSTALLATION_DIR_AVOID_WRITE"):
             path = util.PROFILE
         window = cls(xmlFile=cls.xmlFile, path=path, theme=cls.theme, res=cls.res, **kwargs)
         window.modal()
@@ -53,7 +53,7 @@ class BaseFunctions(object):
     def create(cls, show=True, **kwargs):
         # Use the user addon data directory in installations where the extension installation directory is not writable
         path = cls.path
-        if not os.access(path, os.W_OK):
+        if os.getenv("INSTALLATION_DIR_AVOID_WRITE"):
             path = util.PROFILE
         window = cls(xmlFile=cls.xmlFile, path=path, theme=cls.theme, res=cls.res, **kwargs)
 


### PR DESCRIPTION
also silence a warning in the commented out code

On some operating systems, this is available as a as being installable through the system package manager. At least, in nixos it is, and so I am packaging and patching it for that. However in that case the directory the addon is installed to is not actually writable, so when you go to create the templates, it fails. This fixes that by checking if the directory is writable and if it is not, redirects the templates to the user addon data directory.

Since this is wrapped in a check, it shouldn't affect any other code except on systems that need it, but if you don't want to merge then I can continue just patching it on nix


## Description:

## Checklist:
- [ x ] I have based this PR against the develop branch
