### PR TITLE
Bring back screensaver.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -15,6 +15,7 @@
     <extension point="xbmc.python.pluginsource" library="plugin.py">
         <provides>executable</provides>
     </extension>
+    <extension point="xbmc.ui.screensaver" library="screensaver.py"/>
     <extension point="xbmc.service" library="service.py" />
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">PlexMod for Kodi</summary>


### PR DESCRIPTION
GHI (If applicable): N/A

## Description:
I had put in the screensaver in the original addon and it seems to have been lost in the various merges since then.  It appears all that's missing is the extension definition.  I made the change locally and it appears to work.

This was originally added in d42d2f89020c22d9570555f34e788add5d78902d

## Checklist:
- [X] I have based this PR against the develop branch
