### PR TITLE
Collection Hubs on Movie Preplay Screen

### DIFF
--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -4,7 +4,7 @@ import os
 
 from kodi_six import xbmc
 from kodi_six import xbmcgui
-from plexnet import plexplayer, media, util as pnUtil, plexapp, plexlibrary, playlist, playqueue
+from plexnet import plexplayer, media, plexobjects, util as pnUtil, plexapp, plexlibrary, playlist, playqueue
 
 from lib import metadata
 from lib import util
@@ -36,6 +36,44 @@ class RelatedPaginator(pagination.BaseRelatedPaginator):
         return self.parentWindow.video.getRelated(offset=offset, limit=amount)
 
 
+class CollectionPaginator(pagination.BaseRelatedPaginator):
+    initialPageSize = 10
+    pageSize = 8
+    orphans = 4
+    thumbFallback = 'script.plex/thumb_fallbacks/movie.png'
+
+    def setup(self, server, path):
+        self._server = server
+        self._path = path
+        return self
+
+    @property
+    def initialPage(self):
+        data = self.getData(self.offset, self.initialPageSize)
+        if data:
+            self._lastAmount = self._currentAmount
+            self._currentAmount = len(data)
+            return data
+
+    def getData(self, offset, amount):
+        items = plexobjects.listItems(self._server, self._path, offset=offset, limit=amount)
+        if not self.leafCount:
+            self.leafCount = int(items.totalSize or 0) or len(items)
+        return items
+
+    def createListItem(self, item):
+        return kodigui.ManagedListItem(
+            item.title or '',
+            thumbnailImage=item.defaultThumb.asTranscodedImageURL(*self.parentWindow.RELATED_DIM),
+            data_source=item
+        )
+
+    def prepareListItem(self, item, mli):
+        mli.setProperty('unwatched', not item.isWatched and '1' or '')
+        mli.setBoolProperty('watched', item.isFullyWatched)
+        mli.setProperty('progress', util.getProgressImage(item))
+
+
 class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixin, PlaybackBtnMixin, ThemeMusicMixin,
                     RolesMixin, CommonMixin, WatchlistUtilsMixin, TasksMixin):
     xmlFile = 'script-plex-pre_play.xml'
@@ -57,6 +95,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
     REVIEWS_LIST_ID = 401
     EXTRA_LIST_ID = 402
     RELATED_LIST_ID = 403
+    COLLECTION_LIST_IDS = [404, 405, 406]
 
     OPTIONS_GROUP_ID = 200
     PROGRESS_IMAGE_ID = 250
@@ -95,6 +134,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
         self.lastNonOptionsFocusID = None
         self.initialized = False
         self.relatedPaginator = None
+        self.collectionPaginators = [None, None, None]
         self.openedWithAutoPlay = False
         self.fromPlayback = False
         self.useBGM = False
@@ -109,6 +149,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
         self.relatedListControl = kodigui.ManagedControlList(self, self.RELATED_LIST_ID, 5)
         self.rolesListControl = kodigui.ManagedControlList(self, self.ROLES_LIST_ID, 5)
         self.reviewsListControl = kodigui.ManagedControlList(self, self.REVIEWS_LIST_ID, 5)
+        self.collectionListControls = [kodigui.ManagedControlList(self, lid, 5) for lid in self.COLLECTION_LIST_IDS]
         self.setBoolProperty("is_watchlisted", self.is_watchlisted)
 
         self.progressImageControl = self.getControl(self.PROGRESS_IMAGE_ID)
@@ -224,6 +265,13 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
                     return
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_MOVE_RIGHT):
                     self.updateBackgroundFrom(self.relatedListControl.getSelectedItem().dataSource)
+
+            if controlID in self.COLLECTION_LIST_IDS:
+                idx = self.COLLECTION_LIST_IDS.index(controlID)
+                paginator = self.collectionPaginators[idx]
+                if paginator and paginator.boundaryHit:
+                    paginator.paginate()
+                    return
         except:
             util.ERROR()
 
@@ -236,6 +284,8 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
             self.openItem(self.extraListControl)
         elif controlID == self.RELATED_LIST_ID:
             self.openItem(self.relatedListControl)
+        elif controlID in self.COLLECTION_LIST_IDS:
+            self.openItem(self.collectionListControls[self.COLLECTION_LIST_IDS.index(controlID)])
         elif controlID == self.ROLES_LIST_ID:
             if self.fromWatchlist:
                 return
@@ -626,7 +676,8 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
         self.batch_simple([(self.fillRoles, None, None),
                            (self.fillReviews, None, None),
                            (self.fillExtras, None, None),
-                           (self.fillRelated, None, None)])
+                           (self.fillRelated, None, None),
+                           (self.fillCollections, None, None)])
 
     def setInfo(self, skip_bg=False):
         if not skip_bg:
@@ -779,6 +830,33 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
             return False
 
         return True
+
+    def fillCollections(self):
+        collections = self.video.collections() if self.video.type == 'movie' and self.video.collections else []
+        section_id = self.video.getLibrarySectionId()
+
+        for i, list_control in enumerate(self.collectionListControls):
+            if i >= len(collections):
+                list_control.reset()
+                self.setProperty('collection.header.{0}'.format(i), '')
+                self.collectionPaginators[i] = None
+                continue
+
+            collection = collections[i]
+            path = '/library/sections/{0}/all?type=1&{1}'.format(section_id, collection.filter)
+            paginator = CollectionPaginator(list_control, parent_window=self, leaf_count=0)
+            paginator.setup(self.video.server, path)
+            try:
+                paginator.paginate()
+            except Exception:
+                util.ERROR()
+                list_control.reset()
+                self.setProperty('collection.header.{0}'.format(i), '')
+                self.collectionPaginators[i] = None
+                continue
+
+            self.collectionPaginators[i] = paginator
+            self.setProperty('collection.header.{0}'.format(i), collection.tag)
 
     def fillRoles(self):
         items = []

--- a/resources/skins/Main/1080i/templates/script-plex-pre_play.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-pre_play.xml.tpl
@@ -15,6 +15,18 @@
         <effect type="slide" end="0,{{ vscale(-500) }}" time="200" tween="quadratic" easing="out"/>
     </animation>
 
+    <animation type="Conditional" condition="Integer.IsGreater(Window.Property(hub.focus),3) + Control.IsVisible(503)" reversible="true">
+        <effect type="slide" end="0,{{ vscale(-500) }}" time="200" tween="quadratic" easing="out"/>
+    </animation>
+
+    <animation type="Conditional" condition="Integer.IsGreater(Window.Property(hub.focus),4) + Control.IsVisible(504)" reversible="true">
+        <effect type="slide" end="0,{{ vscale(-500) }}" time="200" tween="quadratic" easing="out"/>
+    </animation>
+
+    <animation type="Conditional" condition="Integer.IsGreater(Window.Property(hub.focus),5) + Control.IsVisible(505)" reversible="true">
+        <effect type="slide" end="0,{{ vscale(-500) }}" time="200" tween="quadratic" easing="out"/>
+    </animation>
+
     <posx>0</posx>
     <posy>{{ vscale(155) }}</posy>
     <defaultcontrol>101</defaultcontrol>
@@ -368,7 +380,7 @@
         <posx>0</posx>
         <posy>{{ vscale(540) }}</posy>
         <width>1920</width>
-        <height>{{ vscale(1800) }}</height>
+        <height>{{ vscale(3400) }}</height>
 
         <onup>300</onup>
         <itemgap>0</itemgap>
@@ -779,6 +791,40 @@
                                 <textcolor>FFFFFFFF</textcolor>
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture colordiffuse="FF404040">script.plex/white-square.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(right.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(left.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white-l.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>!String.IsEmpty(ListItem.Property(is.updating))</visible>
+                                    <posx>58</posx>
+                                    <posy>{{ vscale(116.5) }}</posy>
+                                    <width>128</width>
+                                    <height>{{ vscale(128) }}</height>
+                                    <texture>script.plex/home/busy.gif</texture>
+                                </control>
+                            </control>
                         </control>
                     </control>
                 </itemlayout>
@@ -895,6 +941,7 @@
                 <width>1920</width>
                 <height>{{ vscale(520) }}</height>
                 <onup>402</onup>
+                <ondown>404</ondown>
                 <onleft>noop</onleft>
                 <onright>noop</onright>
                 <scrolltime>200</scrolltime>
@@ -1114,6 +1161,722 @@
             </control>
         </control>
         <!-- /RELATED -->
+
+        <!-- COLLECTION HUB 0 -->
+        <control type="group" id="504">
+            <visible>Integer.IsGreater(Container(404).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <defaultcontrol>404</defaultcontrol>
+            <width>1920</width>
+            <height>{{ vscale(520) }}</height>
+            <control type="label">
+                <posx>60</posx>
+                <posy>0</posy>
+                <width>1000</width>
+                <height>{{ vscale(80) }}</height>
+                <font>font12</font>
+                <align>left</align>
+                <aligny>center</aligny>
+                <textcolor>FFFFFFFF</textcolor>
+                <label>[UPPERCASE]$INFO[Window.Property(collection.header.0)][/UPPERCASE]</label>
+            </control>
+            <control type="list" id="404">
+                <posx>0</posx>
+                <posy>{{ vscale(16) }}</posy>
+                <width>1920</width>
+                <height>{{ vscale(520) }}</height>
+                <onup>403</onup>
+                <ondown>405</ondown>
+                <onleft>noop</onleft>
+                <onright>noop</onright>
+                <scrolltime>200</scrolltime>
+                <orientation>horizontal</orientation>
+                <preloaditems>4</preloaditems>
+                <itemlayout width="304">
+                    <control type="group">
+                        <posx>55</posx>
+                        <posy>{{ vscale(72) }}</posy>
+                        <control type="group">
+                            <posx>5</posx>
+                            <posy>5</posy>
+                            <control type="image">
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>244</width>
+                                <height>{{ vscale(361) }}</height>
+                                <texture>$INFO[ListItem.Property(thumb.fallback)]</texture>
+                            </control>
+                            <control type="image">
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>244</width>
+                                <height>{{ vscale(361) }}</height>
+                                <texture background="true">$INFO[ListItem.Thumb]</texture>
+                                <aspectratio>scale</aspectratio>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                <posx>0</posx>
+                                <posy>{{ vscale(351) }}</posy>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(10) }}</height>
+                                    <texture>script.plex/white-square.png</texture>
+                                    <colordiffuse>C0000000</colordiffuse>
+                                </control>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>1</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(8) }}</height>
+                                    <texture>$INFO[ListItem.Property(progress)]</texture>
+                                    <colordiffuse>FFCC7B19</colordiffuse>
+                                </control>
+                            </control>
+                            {% include "includes/watched_indicator.xml.tpl" with xoff=244 & uw_size=48 & with_count=True & scale="medium" %}
+                            <control type="label">
+                                <scroll>false</scroll>
+                                <posx>0</posx>
+                                <posy>{{ vscale(369) }}</posy>
+                                <width>244</width>
+                                <height>{{ vscale(38) }}</height>
+                                <font>font10</font>
+                                <align>center</align>
+                                <textcolor>FFFFFFFF</textcolor>
+                                <label>$INFO[ListItem.Label]</label>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture colordiffuse="FF404040">script.plex/white-square.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(right.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(left.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white-l.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>!String.IsEmpty(ListItem.Property(is.updating))</visible>
+                                    <posx>58</posx>
+                                    <posy>{{ vscale(116.5) }}</posy>
+                                    <width>128</width>
+                                    <height>{{ vscale(128) }}</height>
+                                    <texture>script.plex/home/busy.gif</texture>
+                                </control>
+                            </control>
+                        </control>
+                    </control>
+                </itemlayout>
+                <focusedlayout width="304">
+                    <control type="group">
+                        <posx>55</posx>
+                        <posy>{{ vscale(72) }}</posy>
+                        <control type="group">
+                            <animation effect="zoom" start="100" end="110" time="100" center="127,{{ vscale(180.5) }}" reversible="false">Focus</animation>
+                            <animation effect="zoom" start="110" end="100" time="100" center="127,{{ vscale(180.5) }}" reversible="false">UnFocus</animation>
+                            <posx>0</posx>
+                            <posy>0</posy>
+                            <control type="image">
+                                <visible>Control.HasFocus(404)</visible>
+                                <posx>-40</posx>
+                                <posy>{{ vscale(-40) }}</posy>
+                                <width>324</width>
+                                <height>{{ vscale(441) }}</height>
+                                <texture border="42">script.plex/drop-shadow.png</texture>
+                            </control>
+                            <control type="group">
+                                <posx>5</posx>
+                                <posy>5</posy>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture>$INFO[ListItem.Property(thumb.fallback)]</texture>
+                                </control>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture background="true">$INFO[ListItem.Thumb]</texture>
+                                    <aspectratio>scale</aspectratio>
+                                </control>
+                                <control type="group">
+                                    <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(351) }}</posy>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>244</width>
+                                        <height>{{ vscale(10) }}</height>
+                                        <texture>script.plex/white-square.png</texture>
+                                        <colordiffuse>C0000000</colordiffuse>
+                                    </control>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>1</posy>
+                                        <width>244</width>
+                                        <height>{{ vscale(8) }}</height>
+                                        <texture>$INFO[ListItem.Property(progress)]</texture>
+                                        <colordiffuse>FFCC7B19</colordiffuse>
+                                    </control>
+                                </control>
+                                {% include "includes/watched_indicator.xml.tpl" with xoff=244 & uw_size=48 & with_count=True & scale="medium" %}
+                                <control type="label">
+                                    <scroll>Control.HasFocus(404)</scroll>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(369) }}</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(38) }}</height>
+                                    <font>font10</font>
+                                    <align>center</align>
+                                    <textcolor>FFFFFFFF</textcolor>
+                                    <label>$INFO[ListItem.Label]</label>
+                                </control>
+                            </control>
+                            <control type="image">
+                                <visible>Control.HasFocus(404)</visible>
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>254</width>
+                                <height>{{ vscale(371) }}</height>
+                                <texture border="10">script.plex/home/selected.png</texture>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture colordiffuse="FF404040">script.plex/white-square.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(right.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(left.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white-l.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>!String.IsEmpty(ListItem.Property(is.updating))</visible>
+                                    <posx>58</posx>
+                                    <posy>{{ vscale(116.5) }}</posy>
+                                    <width>128</width>
+                                    <height>{{ vscale(128) }}</height>
+                                    <texture>script.plex/home/busy.gif</texture>
+                                </control>
+                            </control>
+                        </control>
+                    </control>
+                </focusedlayout>
+            </control>
+        </control>
+        <!-- /COLLECTION HUB 0 -->
+
+        <!-- COLLECTION HUB 1 -->
+        <control type="group" id="505">
+            <visible>Integer.IsGreater(Container(405).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <defaultcontrol>405</defaultcontrol>
+            <width>1920</width>
+            <height>{{ vscale(520) }}</height>
+            <control type="label">
+                <posx>60</posx>
+                <posy>0</posy>
+                <width>1000</width>
+                <height>{{ vscale(80) }}</height>
+                <font>font12</font>
+                <align>left</align>
+                <aligny>center</aligny>
+                <textcolor>FFFFFFFF</textcolor>
+                <label>[UPPERCASE]$INFO[Window.Property(collection.header.1)][/UPPERCASE]</label>
+            </control>
+            <control type="list" id="405">
+                <posx>0</posx>
+                <posy>{{ vscale(16) }}</posy>
+                <width>1920</width>
+                <height>{{ vscale(520) }}</height>
+                <onup>404</onup>
+                <ondown>406</ondown>
+                <onleft>noop</onleft>
+                <onright>noop</onright>
+                <scrolltime>200</scrolltime>
+                <orientation>horizontal</orientation>
+                <preloaditems>4</preloaditems>
+                <itemlayout width="304">
+                    <control type="group">
+                        <posx>55</posx>
+                        <posy>{{ vscale(72) }}</posy>
+                        <control type="group">
+                            <posx>5</posx>
+                            <posy>5</posy>
+                            <control type="image">
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>244</width>
+                                <height>{{ vscale(361) }}</height>
+                                <texture>$INFO[ListItem.Property(thumb.fallback)]</texture>
+                            </control>
+                            <control type="image">
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>244</width>
+                                <height>{{ vscale(361) }}</height>
+                                <texture background="true">$INFO[ListItem.Thumb]</texture>
+                                <aspectratio>scale</aspectratio>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                <posx>0</posx>
+                                <posy>{{ vscale(351) }}</posy>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(10) }}</height>
+                                    <texture>script.plex/white-square.png</texture>
+                                    <colordiffuse>C0000000</colordiffuse>
+                                </control>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>1</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(8) }}</height>
+                                    <texture>$INFO[ListItem.Property(progress)]</texture>
+                                    <colordiffuse>FFCC7B19</colordiffuse>
+                                </control>
+                            </control>
+                            {% include "includes/watched_indicator.xml.tpl" with xoff=244 & uw_size=48 & with_count=True & scale="medium" %}
+                            <control type="label">
+                                <scroll>false</scroll>
+                                <posx>0</posx>
+                                <posy>{{ vscale(369) }}</posy>
+                                <width>244</width>
+                                <height>{{ vscale(38) }}</height>
+                                <font>font10</font>
+                                <align>center</align>
+                                <textcolor>FFFFFFFF</textcolor>
+                                <label>$INFO[ListItem.Label]</label>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture colordiffuse="FF404040">script.plex/white-square.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(right.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(left.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white-l.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>!String.IsEmpty(ListItem.Property(is.updating))</visible>
+                                    <posx>58</posx>
+                                    <posy>{{ vscale(116.5) }}</posy>
+                                    <width>128</width>
+                                    <height>{{ vscale(128) }}</height>
+                                    <texture>script.plex/home/busy.gif</texture>
+                                </control>
+                            </control>
+                        </control>
+                    </control>
+                </itemlayout>
+                <focusedlayout width="304">
+                    <control type="group">
+                        <posx>55</posx>
+                        <posy>{{ vscale(72) }}</posy>
+                        <control type="group">
+                            <animation effect="zoom" start="100" end="110" time="100" center="127,{{ vscale(180.5) }}" reversible="false">Focus</animation>
+                            <animation effect="zoom" start="110" end="100" time="100" center="127,{{ vscale(180.5) }}" reversible="false">UnFocus</animation>
+                            <posx>0</posx>
+                            <posy>0</posy>
+                            <control type="image">
+                                <visible>Control.HasFocus(405)</visible>
+                                <posx>-40</posx>
+                                <posy>{{ vscale(-40) }}</posy>
+                                <width>324</width>
+                                <height>{{ vscale(441) }}</height>
+                                <texture border="42">script.plex/drop-shadow.png</texture>
+                            </control>
+                            <control type="group">
+                                <posx>5</posx>
+                                <posy>5</posy>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture>$INFO[ListItem.Property(thumb.fallback)]</texture>
+                                </control>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture background="true">$INFO[ListItem.Thumb]</texture>
+                                    <aspectratio>scale</aspectratio>
+                                </control>
+                                <control type="group">
+                                    <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(351) }}</posy>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>244</width>
+                                        <height>{{ vscale(10) }}</height>
+                                        <texture>script.plex/white-square.png</texture>
+                                        <colordiffuse>C0000000</colordiffuse>
+                                    </control>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>1</posy>
+                                        <width>244</width>
+                                        <height>{{ vscale(8) }}</height>
+                                        <texture>$INFO[ListItem.Property(progress)]</texture>
+                                        <colordiffuse>FFCC7B19</colordiffuse>
+                                    </control>
+                                </control>
+                                {% include "includes/watched_indicator.xml.tpl" with xoff=244 & uw_size=48 & with_count=True & scale="medium" %}
+                                <control type="label">
+                                    <scroll>Control.HasFocus(405)</scroll>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(369) }}</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(38) }}</height>
+                                    <font>font10</font>
+                                    <align>center</align>
+                                    <textcolor>FFFFFFFF</textcolor>
+                                    <label>$INFO[ListItem.Label]</label>
+                                </control>
+                            </control>
+                            <control type="image">
+                                <visible>Control.HasFocus(405)</visible>
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>254</width>
+                                <height>{{ vscale(371) }}</height>
+                                <texture border="10">script.plex/home/selected.png</texture>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture colordiffuse="FF404040">script.plex/white-square.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(right.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(left.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white-l.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>!String.IsEmpty(ListItem.Property(is.updating))</visible>
+                                    <posx>58</posx>
+                                    <posy>{{ vscale(116.5) }}</posy>
+                                    <width>128</width>
+                                    <height>{{ vscale(128) }}</height>
+                                    <texture>script.plex/home/busy.gif</texture>
+                                </control>
+                            </control>
+                        </control>
+                    </control>
+                </focusedlayout>
+            </control>
+        </control>
+        <!-- /COLLECTION HUB 1 -->
+
+        <!-- COLLECTION HUB 2 -->
+        <control type="group" id="506">
+            <visible>Integer.IsGreater(Container(406).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <defaultcontrol>406</defaultcontrol>
+            <width>1920</width>
+            <height>{{ vscale(520) }}</height>
+            <control type="label">
+                <posx>60</posx>
+                <posy>0</posy>
+                <width>1000</width>
+                <height>{{ vscale(80) }}</height>
+                <font>font12</font>
+                <align>left</align>
+                <aligny>center</aligny>
+                <textcolor>FFFFFFFF</textcolor>
+                <label>[UPPERCASE]$INFO[Window.Property(collection.header.2)][/UPPERCASE]</label>
+            </control>
+            <control type="list" id="406">
+                <posx>0</posx>
+                <posy>{{ vscale(16) }}</posy>
+                <width>1920</width>
+                <height>{{ vscale(520) }}</height>
+                <onup>405</onup>
+                <onleft>noop</onleft>
+                <onright>noop</onright>
+                <scrolltime>200</scrolltime>
+                <orientation>horizontal</orientation>
+                <preloaditems>4</preloaditems>
+                <itemlayout width="304">
+                    <control type="group">
+                        <posx>55</posx>
+                        <posy>{{ vscale(72) }}</posy>
+                        <control type="group">
+                            <posx>5</posx>
+                            <posy>5</posy>
+                            <control type="image">
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>244</width>
+                                <height>{{ vscale(361) }}</height>
+                                <texture>$INFO[ListItem.Property(thumb.fallback)]</texture>
+                            </control>
+                            <control type="image">
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>244</width>
+                                <height>{{ vscale(361) }}</height>
+                                <texture background="true">$INFO[ListItem.Thumb]</texture>
+                                <aspectratio>scale</aspectratio>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                <posx>0</posx>
+                                <posy>{{ vscale(351) }}</posy>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(10) }}</height>
+                                    <texture>script.plex/white-square.png</texture>
+                                    <colordiffuse>C0000000</colordiffuse>
+                                </control>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>1</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(8) }}</height>
+                                    <texture>$INFO[ListItem.Property(progress)]</texture>
+                                    <colordiffuse>FFCC7B19</colordiffuse>
+                                </control>
+                            </control>
+                            {% include "includes/watched_indicator.xml.tpl" with xoff=244 & uw_size=48 & with_count=True & scale="medium" %}
+                            <control type="label">
+                                <scroll>false</scroll>
+                                <posx>0</posx>
+                                <posy>{{ vscale(369) }}</posy>
+                                <width>244</width>
+                                <height>{{ vscale(38) }}</height>
+                                <font>font10</font>
+                                <align>center</align>
+                                <textcolor>FFFFFFFF</textcolor>
+                                <label>$INFO[ListItem.Label]</label>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture colordiffuse="FF404040">script.plex/white-square.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(right.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(left.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white-l.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>!String.IsEmpty(ListItem.Property(is.updating))</visible>
+                                    <posx>58</posx>
+                                    <posy>{{ vscale(116.5) }}</posy>
+                                    <width>128</width>
+                                    <height>{{ vscale(128) }}</height>
+                                    <texture>script.plex/home/busy.gif</texture>
+                                </control>
+                            </control>
+                        </control>
+                    </control>
+                </itemlayout>
+                <focusedlayout width="304">
+                    <control type="group">
+                        <posx>55</posx>
+                        <posy>{{ vscale(72) }}</posy>
+                        <control type="group">
+                            <animation effect="zoom" start="100" end="110" time="100" center="127,{{ vscale(180.5) }}" reversible="false">Focus</animation>
+                            <animation effect="zoom" start="110" end="100" time="100" center="127,{{ vscale(180.5) }}" reversible="false">UnFocus</animation>
+                            <posx>0</posx>
+                            <posy>0</posy>
+                            <control type="image">
+                                <visible>Control.HasFocus(406)</visible>
+                                <posx>-40</posx>
+                                <posy>{{ vscale(-40) }}</posy>
+                                <width>324</width>
+                                <height>{{ vscale(441) }}</height>
+                                <texture border="42">script.plex/drop-shadow.png</texture>
+                            </control>
+                            <control type="group">
+                                <posx>5</posx>
+                                <posy>5</posy>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture>$INFO[ListItem.Property(thumb.fallback)]</texture>
+                                </control>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture background="true">$INFO[ListItem.Thumb]</texture>
+                                    <aspectratio>scale</aspectratio>
+                                </control>
+                                <control type="group">
+                                    <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(351) }}</posy>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>0</posy>
+                                        <width>244</width>
+                                        <height>{{ vscale(10) }}</height>
+                                        <texture>script.plex/white-square.png</texture>
+                                        <colordiffuse>C0000000</colordiffuse>
+                                    </control>
+                                    <control type="image">
+                                        <posx>0</posx>
+                                        <posy>1</posy>
+                                        <width>244</width>
+                                        <height>{{ vscale(8) }}</height>
+                                        <texture>$INFO[ListItem.Property(progress)]</texture>
+                                        <colordiffuse>FFCC7B19</colordiffuse>
+                                    </control>
+                                </control>
+                                {% include "includes/watched_indicator.xml.tpl" with xoff=244 & uw_size=48 & with_count=True & scale="medium" %}
+                                <control type="label">
+                                    <scroll>Control.HasFocus(406)</scroll>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(369) }}</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(38) }}</height>
+                                    <font>font10</font>
+                                    <align>center</align>
+                                    <textcolor>FFFFFFFF</textcolor>
+                                    <label>$INFO[ListItem.Label]</label>
+                                </control>
+                            </control>
+                            <control type="image">
+                                <visible>Control.HasFocus(406)</visible>
+                                <posx>0</posx>
+                                <posy>0</posy>
+                                <width>254</width>
+                                <height>{{ vscale(371) }}</height>
+                                <texture border="10">script.plex/home/selected.png</texture>
+                            </control>
+                            <control type="group">
+                                <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
+                                <control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(361) }}</height>
+                                    <texture colordiffuse="FF404040">script.plex/white-square.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(right.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>String.IsEmpty(ListItem.Property(is.updating)) + !String.IsEmpty(ListItem.Property(left.boundary))</visible>
+                                    <posx>91.5</posx>
+                                    <posy>{{ vscale(130.5) }}</posy>
+                                    <width>61</width>
+                                    <height>{{ vscale(100) }}</height>
+                                    <texture colordiffuse="40000000">script.plex/indicators/chevron-white-l.png</texture>
+                                </control>
+                                <control type="image">
+                                    <visible>!String.IsEmpty(ListItem.Property(is.updating))</visible>
+                                    <posx>58</posx>
+                                    <posy>{{ vscale(116.5) }}</posy>
+                                    <width>128</width>
+                                    <height>{{ vscale(128) }}</height>
+                                    <texture>script.plex/home/busy.gif</texture>
+                                </control>
+                            </control>
+                        </control>
+                    </control>
+                </focusedlayout>
+            </control>
+        </control>
+        <!-- /COLLECTION HUB 2 -->
     </control>
 </control>
 {% endblock content %}


### PR DESCRIPTION
  For movies that belong to one or more Plex collections, displays the other movies in those collections as hub rows
  directly on the preplay screen, below the Related Movies section.

  Changes

  lib/windows/preplay.py:
  - fillCollections() — fetches the movie's collections, then fetches items for each collection via the Plex API and
  populates a hub list control
  - Uses a custom CollectionPaginator (subclass of MCLPaginator) to handle pagination with boundary items (grey poster +
   chevron) matching the behaviour of hub rows on the home screen
  - Supports up to 3 concurrent collection hubs (list IDs 404–406, group IDs 504–506)
  - Each hub header shows the collection name; clicking an item opens that movie's preplay screen

  script-plex-pre_play.xml.tpl:
  - Adds three hub rows (404, 405, 406) below the existing Related Movies section
  - Each uses the existing poster card item/focused layouts with watched state, progress bar, and boundary item
  rendering
  - Hub groups are hidden when empty so a movie with no collections (or fewer than 3) shows no empty rows

  Notes

  - Has no effect on TV show or episode preplay screens
  - Collection data is fetched asynchronously on preplay open; the section appears once loaded
  - Related to #220