### PR TITLE
Dynamic hub UX improvements and bug fixes

### DIFF
--- a/lib/_included_packages/plexnet/myplexserver.py
+++ b/lib/_included_packages/plexnet/myplexserver.py
@@ -66,7 +66,7 @@ class PlexDiscoverServer(MyPlexServer):
         #self.session.request = functools.partial(self.session.request, timeout=plexserver.util.PLEXTV_TIMEOUT)
 
 
-    def hubs(self, section=None, count=None, search_query=None, section_ids=None, ignore_hubs=None):
+    def hubs(self, section=None, count=None, search_query=None, section_ids=None):
         hubs = []
 
         self.currentHubs = {} if self.currentHubs is None else self.currentHubs
@@ -101,9 +101,6 @@ class PlexDiscoverServer(MyPlexServer):
                     hubIdent = elem.attrib.get('hubIdentifier')
                     hubTitle = T(34019, "Discover {}").format(elem.attrib.get('title')) if q == '/hubs/sections/home' else elem.attrib.get('title')
                     self.currentHubs["{}:{}".format(section, hubIdent)] = hubTitle
-
-                    if ignore_hubs and "{}:{}".format(section, hubIdent) in ignore_hubs:
-                        continue
 
                     hub = plexlibrary.WatchlistHub(elem, server=self, container=container)
                     hub.title = hubTitle

--- a/lib/_included_packages/plexnet/plexserver.py
+++ b/lib/_included_packages/plexnet/plexserver.py
@@ -144,7 +144,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
     def getPrefs(self):
         return plexobjects.listItems(self, "/:/prefs", bytag=True, cachable=False, not_cachable=True)
 
-    def hubs(self, section=None, count=None, search_query=None, section_ids=None, ignore_hubs=None):
+    def hubs(self, section=None, count=None, search_query=None, section_ids=None):
         hubs = []
 
         params = {"includeMarkers": 1}
@@ -203,9 +203,6 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
 
                 # Skip old-style continue/ondeck hubs when using combined continueWatching
                 if newCW and hubIdent and (hubIdent.startswith('home.continue') or hubIdent.startswith('home.ondeck')):
-                    continue
-
-                if ignore_hubs and "{}:{}".format(section, hubIdent) in ignore_hubs:
                     continue
 
                 hubs.append(plexlibrary.Hub(elem, server=self, container=container))

--- a/lib/windows/dropdown.py
+++ b/lib/windows/dropdown.py
@@ -94,6 +94,11 @@ class DropdownDialog(kodigui.BaseDialog):
         else:
             shadowControl.setHeight(height)
         self.optionsList.setHeight(ol_height)
+        if self.getBoolProperty('scroll'):
+            try:
+                self.getControl(self.SCROLLBAR_ID).setHeight(ol_height)
+            except:
+                pass
 
         if y == "middle":
             y = util.vperci(util.vscale(ol_height))
@@ -169,6 +174,10 @@ class DropdownDialog(kodigui.BaseDialog):
         elif self.suboptionCallback and action == xbmcgui.ACTION_MOVE_RIGHT:
             if self.optionsList.getSelectedItem().dataSource.get("is_sub_list"):
                 self.setChoice()
+                return
+            elif self.getBoolProperty('scroll'):
+                self.setFocusId(self.SCROLLBAR_ID)
+                return
 
         elif controlID == self.SCROLLBAR_ID and action == xbmcgui.ACTION_SELECT_ITEM:
             self.setChoice()

--- a/lib/windows/dropdown.py
+++ b/lib/windows/dropdown.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import time
+
 from kodi_six import xbmc, xbmcgui
 
 from lib import util
@@ -55,6 +57,7 @@ class DropdownDialog(kodigui.BaseDialog):
         self.moveUpperBound = None  # First position that can't be moved to (separator boundary)
         self._justEnteredMoveMode = False  # Flag to skip the SELECT that entered move mode
         self._adjustedY = None  # Actual y position used after overflow adjustment (set in onFirstInit)
+        self._lastMoveTime = 0  # Timestamp of last UP/DOWN action for wrap debounce
 
     @property
     def x(self):
@@ -138,6 +141,10 @@ class DropdownDialog(kodigui.BaseDialog):
 
         if self.roundRobin and action in (xbmcgui.ACTION_MOVE_UP, xbmcgui.ACTION_MOVE_DOWN) and \
                 controlID == self.OPTIONS_LIST_ID:
+            now = time.time()
+            key_held = (now - self._lastMoveTime) < 0.3
+            self._lastMoveTime = now
+
             to_pos = None
             last_index = self.optionsList.size() - 1
 
@@ -151,6 +158,9 @@ class DropdownDialog(kodigui.BaseDialog):
                     to_pos = 0
 
                 if to_pos is not None:
+                    if key_held:
+                        # Key is being held — don't wrap
+                        return
                     self.optionsList.setSelectedItemByPos(to_pos)
                     self.lastSelectedItem = to_pos
                     return

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -61,11 +61,10 @@ class HubsList(list):
 
 
 class SectionHubsTask(backgroundthread.Task):
-    def setup(self, section, callback, section_keys=None, ignore_hubs=None, reselect_pos_dict=None):
+    def setup(self, section, callback, section_keys=None, reselect_pos_dict=None):
         self.section = section
         self.callback = callback
         self.section_keys = section_keys
-        self.ignore_hubs = ignore_hubs
         self.reselect_pos_dict = reselect_pos_dict
         return self
 
@@ -79,8 +78,7 @@ class SectionHubsTask(backgroundthread.Task):
 
         try:
             hubs = HubsList(self.section.server.hubs(self.section.key, count=HUB_PAGE_SIZE,
-                                                                      section_ids=self.section_keys,
-                                                                      ignore_hubs=self.ignore_hubs)).init()
+                                                                      section_ids=self.section_keys)).init()
             hubs.identifier = self.section.key
             if self.isCanceled():
                 return
@@ -1929,8 +1927,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             if already_fetching:
                 continue
 
-            task = SectionHubsTask().setup(section_obj, self.crossSectionHubsCallback, self.wantedSections,
-                                           ignore_hubs=self.ignoredHubs)
+            task = SectionHubsTask().setup(section_obj, self.crossSectionHubsCallback, self.wantedSections)
             self.tasks.append(task)
             backgroundthread.BGThreader.addTask(task)
 
@@ -2000,10 +1997,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             hub_control = self.hubControls[hub_focus]
             hub = hub_control.dataSource
             return hub
-
-    @property
-    def ignoredHubs(self):
-        return [combo for combo, data in self.hubSettings.items() if not data.get("show", True)]
 
     def updateProperties(self, *args, **kwargs):
         self.setBoolProperty('bifurcation_lines', util.getSetting('hubs_bifurcation_lines'))
@@ -2539,7 +2532,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         #    for mli in self.sectionList:
         #        if mli.dataSource is not None and mli.dataSource != self.lastSection:
         #            sections.add(mli.dataSource)
-        #    tasks = [SectionHubsTask().setup(s, self.sectionHubsCallback, self.wantedSections, self.ignoredHubs)
+        #    tasks = [SectionHubsTask().setup(s, self.sectionHubsCallback, self.wantedSections)
         #             for s in [self.lastSection] + list(sections) if not s.server.DEFER_HUBS and s != self.lastSection]
         #else:
         # fetch hubs we need to update
@@ -2819,28 +2812,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                                 'display': T(33029, "Show library: {}").format(T(34000, 'Watchlist'))
                                 })
 
-            if self.hubSettings:
-                had_hidden_hub = False
-                hidden_hubs_opts = []
-                for section_hub_key in self.ignoredHubs:
-                    if not section_hub_key.startswith("None:"):
-                        continue
-
-                    hub_title = section_hub_key
-                    if plexapp.SERVERMANAGER.selectedServer.currentHubs:
-                        hub_title = plexapp.SERVERMANAGER.selectedServer.currentHubs.get(section_hub_key,
-                                                                                         section_hub_key)
-                    hidden_hubs_opts.append({'key': 'show',
-                                    'hub_ident': section_hub_key,
-                                    'display': T(33041, "Show hub: {}").format(hub_title)
-                                    }
-                                   )
-                    had_hidden_hub = True
-
-                if had_section and had_hidden_hub:
-                    options.append(dropdown.SEPARATOR)
-                options += hidden_hubs_opts
-
             # Add Manage Hubs option
             if options:
                 options.append(dropdown.SEPARATOR)
@@ -2888,21 +2859,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                 options.append({'key': 'section_cache_reset', 'display': T(33721, "Clear library cache (not items)")})
                 options.append(dropdown.SEPARATOR)
 
-            if self.hubSettings:
-                for section_hub_key in self.ignoredHubs:
-                    if not section_hub_key.startswith("{}:".format(section.key)):
-                        continue
-
-                    hub_title = section_hub_key
-                    if plexapp.SERVERMANAGER.selectedServer.currentHubs:
-                        hub_title = plexapp.SERVERMANAGER.selectedServer.currentHubs.get(section_hub_key,
-                                                                                         section_hub_key)
-                    options.append({'key': 'show',
-                                    'hub_ident': section_hub_key,
-                                    'display': T(33041, "Show hub: {}").format(hub_title)
-                                    }
-                                   )
-
             # Add Manage Hubs option (not applicable to watchlist - it has no library hubs)
             if section != watchlist_section:
                 options.append(dropdown.SEPARATOR)
@@ -2945,12 +2901,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             self.saveLibrarySettings()
             return self.sectionList[self.sectionList.prev()].dataSource
         elif choice["key"] == "show":
-            if "hub_ident" in choice:
-                if choice["hub_ident"] in self.hubSettings:
-                    self.hubSettings[choice["hub_ident"]]['show'] = True
-                    self.saveHubSettings()
-                    return self.lastSection
-            elif "section_id" in choice:
+            if "section_id" in choice:
                 if choice["section_id"] in self.librarySettings:
                     self.librarySettings[choice["section_id"]]['show'] = True
                     self.saveLibrarySettings()
@@ -3012,28 +2963,43 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         if not mli:
             return
 
-        if mli.dataSource is None or mli.dataSource == kodigui.DUMMY_DATA_SOURCE:
+        if mli.dataSource is None or mli.dataSource is kodigui.DUMMY_DATA_SOURCE:
             return
 
         ds = mli.dataSource
 
-        section_hub_key = "{}:{}".format(self.lastSection.key, hub.hubIdentifier)
+        # Determine the hub's source section and catalog_id
+        is_home = self.lastSection.key is None
+        cross_source = hub.__dict__.get('_crossSectionSource')
+        hub_source_key = cross_source if cross_source is not None else self.lastSection.key
+        hub_is_home = hub_source_key is None
+        clean_identifier = hub.getCleanHubIdentifier(is_home=hub_is_home)
 
-        hub_title = section_hub_key
-        if plexapp.SERVERMANAGER.selectedServer.currentHubs:
-            hub_title = plexapp.SERVERMANAGER.selectedServer.currentHubs.get(section_hub_key,
-                                                                             section_hub_key)
+        # Build catalog_id for Manage Hubs integration
+        if hub_is_home:
+            catalog_id = clean_identifier
+        else:
+            catalog_id = '{}:{}'.format(hub_source_key, clean_identifier)
 
-        clean_identifier = hub.getCleanHubIdentifier()
+        hub_title = hub.__dict__.get('_displayTitle') or hub.title or clean_identifier
 
         select_base = 0
 
         options = []
         has_prev = False
-        # Don't allow hiding the main continue watching / on deck hubs
+        # Don't allow disabling the main continue watching / on deck hubs
         if hub.hubIdentifier not in ("continueWatching", "home.continue", "home.ondeck"):
-            options.append({'key': 'hide', 'display': T(33659, "Hide Hub: {}").format(hub_title)})
+            options.append({'key': 'disable_hub', 'display': T(33659, "Disable Hub: {}").format(hub_title)})
             has_prev = True
+
+            # Offer "Add to Home" when viewing a library section (not Home)
+            if not is_home:
+                # Check if this hub is already on Home
+                home_config = self.hubSettings.get(None, {}) if self.hubSettings else {}
+                home_hubs = home_config.get('hubs', []) if home_config.get('custom') else []
+                already_on_home = any(h.get('catalog_id') == catalog_id for h in home_hubs)
+                if not already_on_home:
+                    options.append({'key': 'add_to_home', 'display': 'Add to Home: {}'.format(hub_title)})
 
         if ds.TYPE in ('episode', 'season', 'movie', 'show'):
             if has_prev:
@@ -3093,12 +3059,24 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         if not choice:
             return
 
-        elif choice["key"] == "hide":
-            if section_hub_key not in self.hubSettings:
-                self.hubSettings[section_hub_key] = {}
-            self.hubSettings[section_hub_key]['show'] = False
+        elif choice["key"] == "disable_hub":
+            # Disable hub via Manage Hubs settings (same as disabling in the dialog)
+            section_key = self.lastSection.key
+            self._ensureCustomConfigExists(section_key)
+            self._disableHub(catalog_id, section_key)
+            self.showHubs(self.lastSection, update=False, force=True)
+            return
+
+        elif choice["key"] == "add_to_home":
+            # Add this hub to Home as a cross-section hub
+            self._ensureCustomConfigExists(None)  # None = Home section
+            home_config = self.hubSettings.get(None, {})
+            hubs_list = home_config.get('hubs', [])
+            # Add at the end
+            new_order = max((h.get('order', 0) for h in hubs_list), default=-1) + 1
+            hubs_list.append({'catalog_id': catalog_id, 'order': new_order})
             self.saveHubSettings()
-            return self.lastSection
+            return
 
         elif choice["key"] in ("mark_watched", "mark_unwatched"):
             if util.getSetting('home_confirm_actions'):
@@ -3612,7 +3590,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                     if not any(str(s.key) == str_key for s in fetch_sections):
                         fetch_sections.append(self.allSections[str_key])
 
-            self.tasks = [SectionHubsTask().setup(s, self.sectionHubsCallback, self.wantedSections, self.ignoredHubs)
+            self.tasks = [SectionHubsTask().setup(s, self.sectionHubsCallback, self.wantedSections)
                           for s in [home_section] + fetch_sections if not s.server.DEFER_HUBS]
             # Track pending library sections for cross-section hub rendering
             self._pendingLibrarySections = len([s for s in fetch_sections if not s.server.DEFER_HUBS])
@@ -3734,8 +3712,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                 if section.key in self.sectionHubs:
                     self.sectionHubs[section.key] = None
             task = SectionHubsTask().setup(section, self.sectionHubsCallback, self.wantedSections,
-                                           reselect_pos_dict=rpd,
-                                           ignore_hubs=self.ignoredHubs)
+                                           reselect_pos_dict=rpd)
             self.tasks.append(task)
             backgroundthread.BGThreader.addTask(task)
             return

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -1705,6 +1705,16 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             del self.hubSettings[config_key]
             self.saveHubSettings()
 
+    def hasCrossSectionHubs(self, section_key):
+        """Check if a section has any cross-section hubs configured."""
+        required = self.getRequiredSourceSections(section_key)
+        str_key = str(section_key) if section_key is not None else None
+        for source in required:
+            str_source = str(source) if source is not None else None
+            if str_source != str_key:
+                return True
+        return False
+
     def getRequiredSourceSections(self, section_key):
         """Get list of source section keys needed for this section's custom hub config."""
         required = set()
@@ -2169,7 +2179,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
         # Cancel any pending Home refresh
         self._homeRefreshScheduled = 0
-        self._homeNeedsRefresh = False
 
         #if self.sectionChangeThread and self.sectionChangeThread.isAlive():
         #    self.sectionChangeThread.join(timeout=2.0)
@@ -2597,7 +2606,9 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         section = kwargs.pop("section", None)
         self.showSections(focus_section=section or home_section)
         self.backgroundSet = False
-        self.showHubs(section if section else home_section)
+        # Don't call showHubs() here — showSections() just cleared sectionHubs,
+        # so there's nothing to draw. Let background tasks call showHubs() via
+        # sectionHubsCallback when data actually arrives.
 
     def disableUpdates(self, *args, **kwargs):
         util.LOG("Sleep event, stopping updates")
@@ -3385,7 +3396,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
             # Cancel any pending Home refresh when switching sections
             self._homeRefreshScheduled = 0
-            self._homeNeedsRefresh = False
 
             self.setProperty('hub.focus', '')
             if util.addonSettings.dynamicBackgrounds:
@@ -3417,34 +3427,36 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
             self.sectionHubs[section.key] = sorted_hubs
             self.setBoolProperty('loading.content', False)
-            if self.lastSection == section:
-                self.showHubs(section, update=update, reselect_pos_dict=reselect_pos_dict)
-                # If this is Home completing and library sections already finished, check if refresh needed
-                if section.key is None:
+
+            on_home = self.lastSection and self.lastSection.key is None
+            has_cross = self.hasCrossSectionHubs(None) if on_home else False
+
+            if is_home:
+                if has_cross:
+                    # Cross-section hubs need library data — defer drawing until all libraries complete
                     pending = getattr(self, '_pendingLibrarySections', -1)
-                    needs_refresh = getattr(self, '_homeNeedsRefresh', False)
-                    if pending == 0 and needs_refresh:
-                        self._homeNeedsRefresh = False
-                        self.showHubs(section, update=False)
-            # Track library section completion for Home refresh
-            if section.key is not None:
+                    if pending == 0:
+                        # All libraries already done, draw now
+                        self.showHubs(section, update=update, reselect_pos_dict=reselect_pos_dict)
+                    # else: wait for library tasks to finish
+                else:
+                    # No cross-section hubs — draw immediately
+                    self.showHubs(section, update=update, reselect_pos_dict=reselect_pos_dict)
+            else:
+                # Library section completed
+                if self.lastSection == section:
+                    # User is viewing this library section — draw it
+                    self.showHubs(section, update=update, reselect_pos_dict=reselect_pos_dict)
+
+                # Track library section completion
                 pending = getattr(self, '_pendingLibrarySections', 0)
                 if pending > 0:
                     self._pendingLibrarySections = pending - 1
 
-                # If we're on Home, mark that Home needs refresh (works for both default and custom config)
-                # Custom config might include hubs from this library section
-                if self.lastSection and self.lastSection.key is None:
-                    self._homeNeedsRefresh = True
-
-                # When all library sections are complete and Home needs refresh, do it
-                if self._pendingLibrarySections == 0 and getattr(self, '_homeNeedsRefresh', False):
-                    if self.lastSection and self.lastSection.key is None:
-                        if self.sectionHubs.get(None) is not None:
-                            self._homeNeedsRefresh = False  # Only clear flag if we actually refresh
-                            self.showHubs(self.lastSection, update=False)
-                        else:
-                            pass
+                # When all libraries are done and we're on Home with cross-section hubs, draw once
+                if self._pendingLibrarySections == 0 and on_home and has_cross:
+                    if self.sectionHubs.get(None) is not None:
+                        self.showHubs(self.lastSection, update=False)
 
     def _scheduleHomeRefresh(self):
         """Schedule a debounced Home refresh using BGThreader.
@@ -3591,11 +3603,19 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             self.wantedSections = None
 
         if plexapp.SERVERMANAGER.selectedServer.hasHubs():
+            # Include hidden sections that are needed for cross-section hubs
+            fetch_sections = list(sections)
+            required_sources = self.getRequiredSourceSections(None)  # Home's required sources
+            for source_key in required_sources:
+                str_key = str(source_key) if source_key is not None else None
+                if str_key and str_key in self.allSections:
+                    if not any(str(s.key) == str_key for s in fetch_sections):
+                        fetch_sections.append(self.allSections[str_key])
+
             self.tasks = [SectionHubsTask().setup(s, self.sectionHubsCallback, self.wantedSections, self.ignoredHubs)
-                          for s in [home_section] + sections if not s.server.DEFER_HUBS]
-            # Track pending library sections for Home refresh after all complete
-            self._pendingLibrarySections = len([s for s in sections if not s.server.DEFER_HUBS])
-            self._homeNeedsRefresh = False
+                          for s in [home_section] + fetch_sections if not s.server.DEFER_HUBS]
+            # Track pending library sections for cross-section hub rendering
+            self._pendingLibrarySections = len([s for s in fetch_sections if not s.server.DEFER_HUBS])
             backgroundthread.BGThreader.addTasks(self.tasks)
 
         show_pm_indicator = util.getSetting('path_mapping_indicators')

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -3747,6 +3747,21 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         if combined_hubs is not None and len(combined_hubs) > 0:
             hubs = combined_hubs
 
+        # On Home, append library name to hubs where it's not already in the title
+        is_home = section.key is None
+        for hub in hubs:
+            hub.__dict__.pop('_displayTitle', None)  # Clear stale display titles
+            if is_home and hub.title:
+                source_key = hub.__dict__.get('_crossSectionSource')
+                if source_key is None and hub.hubIdentifier:
+                    parts = hub.hubIdentifier.rsplit('.', 2)
+                    if len(parts) >= 2 and parts[-2].isdigit():
+                        source_key = parts[-2]
+                if source_key is not None:
+                    section_obj = self.allSections.get(str(source_key))
+                    if section_obj and section_obj.title.lower() not in hub.title.lower():
+                        hub._displayTitle = u'{} \u2014 {}'.format(hub.title, section_obj.title)
+
         # Sequential slot assignment - hubs are assigned to slots in order
         # Display type is determined per-hub and set as a window property for the skin
         hasContent = False
@@ -4011,7 +4026,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         if not hubitems:
             hub.reset()
 
-        self.setProperty('hub.4{0:02d}'.format(index), hub.title or kwargs.get('title'))
+        display_title = hub.__dict__.get('_displayTitle') or hub.title or kwargs.get('title')
+        self.setProperty('hub.4{0:02d}'.format(index), display_title)
         self.setProperty('hub.text2lines.4{0:02d}'.format(index), text2lines and '1' or '')
 
         use_reselect_pos = False

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -2325,7 +2325,7 @@ msgid "Disable Auto-Sync"
 msgstr ""
 
 msgctxt "#33659"
-msgid "Hide hub: {}"
+msgid "Disable Hub: {}"
 msgstr ""
 
 msgctxt "#33660"

--- a/resources/skins/Main/1080i/templates/script-plex-dropdown_header.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-dropdown_header.xml.tpl
@@ -59,11 +59,13 @@
         <onup condition="String.IsEqual(Window.Property(close.direction),top)">Close</onup>
         <onup condition="!String.IsEqual(Window.Property(close.direction),top)">noop</onup>
         <onleft condition="String.IsEqual(Window.Property(close.direction),left)">Close</onleft>
+        <onright condition="!String.IsEmpty(Window.Property(scroll))">1152</onright>
         <onright condition="String.IsEqual(Window.Property(close.direction),right)">Close</onright>
         <ondown condition="String.IsEqual(Window.Property(close.direction),down)">Close</ondown>
         <ondown condition="!String.IsEqual(Window.Property(close.direction),down)">noop</ondown>
         <scrolltime>200</scrolltime>
         <orientation>vertical</orientation>
+        <pagecontrol>1152</pagecontrol>
         <!-- ITEM LAYOUT ########################################## -->
         <itemlayout height="{{ vscale(66) }}">
             <control type="image">
@@ -339,6 +341,23 @@
                 <texture colordiffuse="FF000000">script.plex/white-square.png</texture>
             </control>
         </focusedlayout>
+    </control>
+    <control type="scrollbar" id="1152">
+        <hitrect x="600" y="0" w="50" h="{{ vscale(528) }}" />
+        <left>604</left>
+        <top>0</top>
+        <width>12</width>
+        <height>{{ vscale(528) }}</height>
+        <visible>true</visible>
+        <texturesliderbackground colordiffuse="40000000" border="5">script.plex/white-square-rounded.png</texturesliderbackground>
+        <texturesliderbar colordiffuse="77FFFFFF" border="5">script.plex/white-square-rounded.png</texturesliderbar>
+        <texturesliderbarfocus colordiffuse="FFE5A00D" border="5">script.plex/white-square-rounded.png</texturesliderbarfocus>
+        <textureslidernib>-</textureslidernib>
+        <textureslidernibfocus>-</textureslidernibfocus>
+        <pulseonselect>false</pulseonselect>
+        <orientation>vertical</orientation>
+        <showonepage>false</showonepage>
+        <onleft>250</onleft>
     </control>
 </control>
 {% endblock controls %}


### PR DESCRIPTION
 ## Summary
  - Eliminate double refresh on initial home hub load
  - Disambiguate hub titles on Home by appending source library name (e.g. "Rediscover — Movies")
  - Debounce round-robin wrap in dropdown when UP/DOWN is held
  - Replace Hide Hub with Disable Hub (uses Manage Hubs config instead of old `ignoredHubs` system)
  - Add "Add to Home" option on library hub long-press
  - Fix context menu crash on photo/music hubs
  - Add scrollbar to Manage Hubs dropdown list