### PR TITLE
Fix: VS10 button string ID collision and missing button for existing …

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -588,6 +588,15 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         util.setGlobalBoolProperty('off.sections', '')
 
     def onFirstInit(self):
+        # Migrate existing CE_VS10 users: inject video_show_vs10 into saved button list
+        # if it was saved before the VS10 feature existed
+        if util.CE_VS10 and not util.getSetting('vs10_button_migrated', False):
+            button_settings = util.getUserSetting('player_show_buttons', None)
+            if button_settings is not None and 'video_show_vs10' not in button_settings:
+                button_settings.append('video_show_vs10')
+                util.setSetting('player_show_buttons.{}'.format(plexapp.ACCOUNT.ID), button_settings)
+            util.setSetting('vs10_button_migrated', True)
+
         # set last BG image if possible
         if util.addonSettings.dynamicBackgrounds:
             bgUrl = util.getSetting("last_bg_url.{}".format(plexapp.ACCOUNT.ID))

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -444,7 +444,9 @@ class SeekDialog(kodigui.BaseDialog, windowutils.GoHomeMixin, PlexSubtitleDownlo
         self.bigSeekGroupControl = self.getControl(self.BIG_SEEK_GROUP_ID)
         self.initialized = True
 
-        button_settings = util.getUserSetting('player_show_buttons', ['subtitle_downloads', 'skip_intro', 'skip_credits'])
+        button_defaults = ['subtitle_downloads', 'skip_intro', 'skip_credits'] + \
+            (['video_show_vs10'] if util.CE_VS10 else [])
+        button_settings = util.getUserSetting('player_show_buttons', button_defaults)
         showQuickSubs = 'subtitle_downloads' in button_settings
         showRepeat = 'video_show_repeat' in button_settings
         showFfwdRwd = 'video_show_ffwdrwd' in button_settings

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -822,7 +822,7 @@ class Settings(object):
                         ('skip_intro', T(32495, 'Skip Intro')),
                         ('skip_credits', T(32496, 'Skip Credits')),
                     ) + (
-                        (('video_show_vs10', T(34080, 'VS10 Mode')),) if util.CE_VS10 else ()
+                        (('video_show_vs10', T(34090, 'VS10 Mode')),) if util.CE_VS10 else ()
                     )
                 ).description(T(32939, 'Only applies to video player UI')),
                 MultiUAOptionsSetting(

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3015,6 +3015,10 @@ msgctxt "#34089"
 msgid "Move"
 msgstr ""
 
+msgctxt "#34090"
+msgid "VS10 Mode"
+msgstr ""
+
 msgctxt "#34087"
 msgid "Hub Count"
 msgstr ""


### PR DESCRIPTION
 ## Summary
  - Fix VS10 Mode setting label showing "Manage Hubs" due to string ID collision (34080 → 34090)
  - Fix VS10 button not showing for new users (seekdialog default didn't match settings UI default)
  - Fix VS10 button not showing for existing users by migrating saved button settings on first home load