### PR TITLE
Dynamic hub fixes and improvements

### DIFF
--- a/lib/_included_packages/plexnet/plexlibrary.py
+++ b/lib/_included_packages/plexnet/plexlibrary.py
@@ -854,11 +854,13 @@ class PlaylistHub(BaseHub):
 class AudioPlaylistHub(PlaylistHub):
     type = 'audio'
     hubIdentifier = 'playlists.audio'
+    title = 'Audio Playlists'
 
 
 class VideoPlaylistHub(PlaylistHub):
     type = 'video'
     hubIdentifier = 'playlists.video'
+    title = 'Video Playlists'
 
 
 SECTION_TYPES = {

--- a/lib/_included_packages/plexnet/plexlibrary.py
+++ b/lib/_included_packages/plexnet/plexlibrary.py
@@ -854,13 +854,11 @@ class PlaylistHub(BaseHub):
 class AudioPlaylistHub(PlaylistHub):
     type = 'audio'
     hubIdentifier = 'playlists.audio'
-    title = 'Audio Playlists'
 
 
 class VideoPlaylistHub(PlaylistHub):
     type = 'video'
     hubIdentifier = 'playlists.video'
-    title = 'Video Playlists'
 
 
 SECTION_TYPES = {

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -80,6 +80,11 @@ class SectionHubsTask(backgroundthread.Task):
             hubs = HubsList(self.section.server.hubs(self.section.key, count=HUB_PAGE_SIZE,
                                                                       section_ids=self.section_keys)).init()
             hubs.identifier = self.section.key
+            for i, hub in enumerate(hubs):
+                util.DEBUG_LOG(
+                    'SectionHubsTask: section={} [{}] hubIdentifier={} title={}',
+                    self.section.key, i, hub.hubIdentifier, hub.title
+                )
             if self.isCanceled():
                 return
             self.callback(self.section, hubs, reselect_pos_dict=self.reselect_pos_dict)
@@ -208,6 +213,12 @@ class DiscoverHubsTask(backgroundthread.Task):
                     else:
                         catalog_id = '{}:{}'.format(section_key, clean_identifier)
 
+                    util.DEBUG_LOG(
+                        'Hub discovery: section={} hubIdentifier={} clean={} catalog_id={} title={}',
+                        section_key, hub.hubIdentifier, clean_identifier, catalog_id,
+                        hub.title
+                    )
+
                     # Determine native display type from hub content
                     native_display = 'poster'  # Default
                     if hub.items:
@@ -230,6 +241,14 @@ class DiscoverHubsTask(backgroundthread.Task):
                             'native_display': native_display,
                             'item_count': len(hub.items) if hub.items else 0,
                         }
+                    else:
+                        util.DEBUG_LOG(
+                            'Hub discovery: SKIPPED duplicate catalog_id={} title={} hubIdentifier={}'
+                            ' (existing: hubIdentifier={} title={})',
+                            catalog_id, hub.title, hub.hubIdentifier,
+                            availableHubs[catalog_id].get('hubIdentifier'),
+                            availableHubs[catalog_id].get('title')
+                        )
 
 
             except plexnet.exceptions.BadRequest:
@@ -979,6 +998,11 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                     else:
                         catalog_id = '{}:{}'.format(section_key, clean_identifier)
 
+                    util.DEBUG_LOG(
+                        'Hub discovery: section={} hubIdentifier={} clean={} catalog_id={} title={}',
+                        section_key, hub.hubIdentifier, clean_identifier, catalog_id,
+                        hub.title
+                    )
 
                     # Determine native display type from hub content
                     native_display = 'poster'
@@ -998,6 +1022,14 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                             'native_display': native_display,
                             'item_count': len(hub.items) if hub.items else 0,
                         }
+                    else:
+                        util.DEBUG_LOG(
+                            'Hub discovery: SKIPPED duplicate catalog_id={} title={} hubIdentifier={}'
+                            ' (existing: hubIdentifier={} title={})',
+                            catalog_id, hub.title, hub.hubIdentifier,
+                            availableHubs[catalog_id].get('hubIdentifier'),
+                            availableHubs[catalog_id].get('title')
+                        )
 
 
             except plexnet.exceptions.BadRequest:
@@ -1097,6 +1129,21 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         has_custom_config = section_config.get('custom', False)
         configured_hubs = section_config.get('hubs', []) if has_custom_config else []
 
+        util.DEBUG_LOG(
+            'Manage Hubs: section_key={} has_custom_config={} configured_hubs={}',
+            section_key, has_custom_config, configured_hubs
+        )
+
+        # Log cached hubs on screen for this section
+        cached_hubs_debug = self.sectionHubs.get(section_key, [])
+        is_home_debug = section_key is None
+        for i, hub in enumerate(cached_hubs_debug):
+            util.DEBUG_LOG(
+                'Manage Hubs: sectionHubs[{}][{}] hubIdentifier={} clean={} title={}',
+                section_key, i, hub.hubIdentifier,
+                hub.getCleanHubIdentifier(is_home=is_home_debug), hub.title
+            )
+
         configured_catalog_ids = {h.get('catalog_id', h.get('identifier')) for h in configured_hubs}
 
         # Determine enabled/disabled state for all hubs
@@ -1195,8 +1242,9 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             for catalog_id, hub_info, is_enabled in sorted(hubs_by_source[source], key=lambda x: x[1].get('title', '')):
                 options.append(make_option(catalog_id, hub_info, is_enabled))
 
-        # Reset option at the end
+        # Reset and refresh options at the end
         options.append(dropdown.SEPARATOR)
+        options.append({'key': 'refresh_hubs', 'display': T(34093, "Refresh Hub List")})
         options.append({'key': 'reset_hubs', 'display': T(34081, "Reset to Default")})
 
         return options
@@ -1313,6 +1361,14 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         choice = mli.dataSource
         if not choice:
             return
+
+        # Handle Refresh Hub List - re-discover hubs from server and rebuild list
+        if choice.get('key') == 'refresh_hubs':
+            section_key = getattr(self, '_managingHubsForSection', self.lastSection.key)
+            section_title = getattr(self, '_managingHubsForSectionTitle', '')
+            self._discoverHubsSync()
+            options = self._buildHubSettingsOptions(section_key, section_title)
+            return ('rebuild', options, 0)
 
         # Handle Reset to Defaults - rebuild list in place
         if choice.get('key') == 'reset_hubs':

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -2064,6 +2064,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         plexapp.util.APP.on('change:path_mapping_indicators', self.setDirty)
         plexapp.util.APP.on('change:hub_season_thumbnails', self.setDirty)
         plexapp.util.APP.on('change:use_watchlist', self.setDirty)
+        plexapp.util.APP.on('change:hubs_linear', self.onLinearHubsChanged)
         plexapp.util.APP.on('change:hubs_use_new_continue_watching', self.onContinueWatchingModeChanged)
         plexapp.util.APP.on('change:force_pd_mapping', self.setHostsDirty)
         plexapp.util.APP.on('change:debug', self.setDebugFlag)
@@ -2096,6 +2097,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         plexapp.util.APP.off('change:path_mapping_indicators', self.setDirty)
         plexapp.util.APP.off('change:hub_season_thumbnails', self.setDirty)
         plexapp.util.APP.off('change:use_watchlist', self.setDirty)
+        plexapp.util.APP.off('change:hubs_linear', self.onLinearHubsChanged)
         plexapp.util.APP.off('change:force_pd_mapping', self.setHostsDirty)
         plexapp.util.APP.off('change:debug', self.setDebugFlag)
         plexapp.util.APP.off('change:update_source', self.updateSourceChanged)
@@ -2584,6 +2586,19 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
     def setThemeDirty(self, *args, **kwargs):
         self._applyTheme = util.getSetting("theme")
+
+    def onLinearHubsChanged(self, *args, **kwargs):
+        """Handle change in Linear Hubs setting - clear all hub caches and re-fetch."""
+        try:
+            # Clear hub caches for all sections since random hubs can appear anywhere
+            self.sectionHubs.clear()
+
+            self._reloadOnReinit = True
+
+            if self.lastSection:
+                self.showHubs(self.lastSection, force=True)
+        except Exception as e:
+            util.ERROR("Error in onLinearHubsChanged: {}".format(e))
 
     def onContinueWatchingModeChanged(self, *args, **kwargs):
         """Handle change in Continue Watching mode (combined vs separate hubs)."""
@@ -3744,6 +3759,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
         # Append library's name in cross section hubs
         is_home = section.key is None
+        linear_hubs = util.getSetting('hubs_linear', False)
         for hub in hubs:
             hub.__dict__.pop('_displayTitle', None)  # Clear stale display titles
             source_key = hub.__dict__.get('_crossSectionSource') if '_crossSectionSource' in hub.__dict__ else "__UNDEF__"
@@ -3761,6 +3777,19 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                 elif source_is_home and not is_home:
                     # hub's source is Home
                     hub._displayTitle = u'{} \u2014 {}'.format(hub.title, T(32332, 'Home'))
+
+            # Mark randomised hubs in the title when linear mode is off
+            if hub.random == '1' and not linear_hubs:
+                base_title = hub.__dict__.get('_displayTitle', hub.title)
+                if base_title:
+                    hub._displayTitle = u'{} (Random)'.format(base_title)
+
+            # In linear mode, replace random hub items with sorted results from hub.key
+            if hub.random == '1' and linear_hubs and hub.key:
+                try:
+                    hub.items = hub.extend(start=0, size=hub.size.asInt() or 10)
+                except:
+                    pass  # Fall back to the random items if re-fetch fails
 
         # Sequential slot assignment - hubs are assigned to slots in order
         # Display type is determined per-hub and set as a window property for the skin

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -51,6 +51,11 @@ MOVE_SET = frozenset(
 
 NO_HUB = "__NO_HUB__"
 
+PLAYLIST_HUB_TITLES = {
+    'playlists.audio': T(34094, 'Audio Playlists'),
+    'playlists.video': T(34095, 'Video Playlists'),
+}
+
 class HubsList(list):
     identifier = NO_HUB
     def init(self):
@@ -80,11 +85,6 @@ class SectionHubsTask(backgroundthread.Task):
             hubs = HubsList(self.section.server.hubs(self.section.key, count=HUB_PAGE_SIZE,
                                                                       section_ids=self.section_keys)).init()
             hubs.identifier = self.section.key
-            for i, hub in enumerate(hubs):
-                util.DEBUG_LOG(
-                    'SectionHubsTask: section={} [{}] hubIdentifier={} title={}',
-                    self.section.key, i, hub.hubIdentifier, hub.title
-                )
             if self.isCanceled():
                 return
             self.callback(self.section, hubs, reselect_pos_dict=self.reselect_pos_dict)
@@ -197,7 +197,7 @@ class DiscoverHubsTask(backgroundthread.Task):
             try:
                 section_key = section.key
                 section_type = getattr(section, 'type', 'unknown')
-                section_title = getattr(section, 'title', 'Unknown')
+                section_title = getattr(section, 'title', T(32411, 'Unknown'))
 
                 # Fetch hubs for this section
                 hubs = section.server.hubs(section_key, count=HUB_PAGE_SIZE)
@@ -213,12 +213,6 @@ class DiscoverHubsTask(backgroundthread.Task):
                     else:
                         catalog_id = '{}:{}'.format(section_key, clean_identifier)
 
-                    util.DEBUG_LOG(
-                        'Hub discovery: section={} hubIdentifier={} clean={} catalog_id={} title={}',
-                        section_key, hub.hubIdentifier, clean_identifier, catalog_id,
-                        hub.title
-                    )
-
                     # Determine native display type from hub content
                     native_display = 'poster'  # Default
                     if hub.items:
@@ -228,28 +222,24 @@ class DiscoverHubsTask(backgroundthread.Task):
                             'album': 'square', 'artist': 'square', 'photo': 'square', 'track': 'square',
                         }.get(item_type, 'poster')
 
+                    # Resolve hub title — playlist hubs have no server-provided title
+                    hub_title = hub.title
+                    if not hub_title:
+                        hub_title = PLAYLIST_HUB_TITLES.get(clean_identifier, clean_identifier)
+
                     # Store hub info - each section's hubs are stored separately
                     if catalog_id not in availableHubs:
                         availableHubs[catalog_id] = {
                             'catalog_id': str(catalog_id),
                             'identifier': str(clean_identifier),
-                            'title': str(hub.title) if hub.title else clean_identifier,
+                            'title': str(hub_title),
                             'hubIdentifier': str(hub.hubIdentifier),
                             'source_section_key': section_key,
-                            'source_section_title': str(section_title) if section_title else 'Unknown',
+                            'source_section_title': str(section_title) if section_title else T(32411, 'Unknown'),
                             'source_section_type': str(section_type) if section_type else 'unknown',
                             'native_display': native_display,
                             'item_count': len(hub.items) if hub.items else 0,
                         }
-                    else:
-                        util.DEBUG_LOG(
-                            'Hub discovery: SKIPPED duplicate catalog_id={} title={} hubIdentifier={}'
-                            ' (existing: hubIdentifier={} title={})',
-                            catalog_id, hub.title, hub.hubIdentifier,
-                            availableHubs[catalog_id].get('hubIdentifier'),
-                            availableHubs[catalog_id].get('title')
-                        )
-
 
             except plexnet.exceptions.BadRequest:
                 pass
@@ -987,7 +977,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             try:
                 section_key = section.key
                 section_type = getattr(section, 'type', 'unknown')
-                section_title = getattr(section, 'title', 'Unknown')
+                section_title = getattr(section, 'title', T(32411, 'Unknown'))
 
                 # Fetch hubs for this section
                 hubs = section.server.hubs(section_key, count=HUB_PAGE_SIZE)
@@ -1001,39 +991,29 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                     else:
                         catalog_id = '{}:{}'.format(section_key, clean_identifier)
 
-                    util.DEBUG_LOG(
-                        'Hub discovery: section={} hubIdentifier={} clean={} catalog_id={} title={}',
-                        section_key, hub.hubIdentifier, clean_identifier, catalog_id,
-                        hub.title
-                    )
-
                     # Determine native display type from hub content
                     native_display = 'poster'
                     if hub.items:
                         item_type = hub.items[0].type
                         native_display = self.TYPE_TO_DISPLAY.get(item_type, 'poster')
 
+                    # Resolve hub title — playlist hubs have no server-provided title
+                    hub_title = hub.title
+                    if not hub_title:
+                        hub_title = PLAYLIST_HUB_TITLES.get(clean_identifier, clean_identifier)
+
                     if catalog_id not in availableHubs:
                         availableHubs[catalog_id] = {
                             'catalog_id': str(catalog_id),
                             'identifier': str(clean_identifier),
-                            'title': str(hub.title) if hub.title else clean_identifier,
+                            'title': str(hub_title),
                             'hubIdentifier': str(hub.hubIdentifier),
                             'source_section_key': section_key,
-                            'source_section_title': str(section_title) if section_title else 'Unknown',
+                            'source_section_title': str(section_title) if section_title else T(32411, 'Unknown'),
                             'source_section_type': str(section_type) if section_type else 'unknown',
                             'native_display': native_display,
                             'item_count': len(hub.items) if hub.items else 0,
                         }
-                    else:
-                        util.DEBUG_LOG(
-                            'Hub discovery: SKIPPED duplicate catalog_id={} title={} hubIdentifier={}'
-                            ' (existing: hubIdentifier={} title={})',
-                            catalog_id, hub.title, hub.hubIdentifier,
-                            availableHubs[catalog_id].get('hubIdentifier'),
-                            availableHubs[catalog_id].get('title')
-                        )
-
 
             except plexnet.exceptions.BadRequest:
                 pass
@@ -1132,21 +1112,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         has_custom_config = section_config.get('custom', False)
         configured_hubs = section_config.get('hubs', []) if has_custom_config else []
 
-        util.DEBUG_LOG(
-            'Manage Hubs: section_key={} has_custom_config={} configured_hubs={}',
-            section_key, has_custom_config, configured_hubs
-        )
-
-        # Log cached hubs on screen for this section
-        cached_hubs_debug = self.sectionHubs.get(section_key, [])
-        is_home_debug = section_key is None
-        for i, hub in enumerate(cached_hubs_debug):
-            util.DEBUG_LOG(
-                'Manage Hubs: sectionHubs[{}][{}] hubIdentifier={} clean={} title={}',
-                section_key, i, hub.hubIdentifier,
-                hub.getCleanHubIdentifier(is_home=is_home_debug), hub.title
-            )
-
         configured_catalog_ids = {h.get('catalog_id', h.get('identifier')) for h in configured_hubs}
 
         # Determine enabled/disabled state for all hubs
@@ -1168,8 +1133,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         def make_option(catalog_id, hub_info, is_enabled, position=None):
             base_title = hub_info.get('title', catalog_id)
             if 'collection' in hub_info.get('identifier', ''):
-                base_title = u'{} (Collection)'.format(base_title)
-            source_label = hub_info.get('source_section_title', 'Unknown')
+                base_title = u'{} ({})'.format(base_title, T(32382, 'Collection'))
+            source_label = hub_info.get('source_section_title', T(32411, 'Unknown'))
             if position is not None:
                 display_title = u'{}. {} [{}]'.format(position, base_title, source_label)
             else:
@@ -1225,7 +1190,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         for catalog_id, (is_enabled, hub_info) in hub_states.items():
             if catalog_id in enabled_hubs_shown:
                 continue
-            source = hub_info.get('source_section_title', 'Unknown')
+            source = hub_info.get('source_section_title', T(32411, 'Unknown'))
             if source not in hubs_by_source:
                 hubs_by_source[source] = []
             hubs_by_source[source].append((catalog_id, hub_info, is_enabled))
@@ -1626,7 +1591,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
             # Backfill availableHubs so _buildHubSettingsOptions can display this hub
             if cat_id not in self.availableHubs:
-                source_title = 'Home'
+                source_title = T(32332, 'Home')
                 source_type = 'home'
                 if section_key is not None:
                     source_section = self.allSections.get(str(section_key))
@@ -1637,7 +1602,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                 self.availableHubs[cat_id] = {
                     'catalog_id': str(cat_id),
                     'identifier': str(hub_identifier),
-                    'title': str(hub.title) if hub.title else hub_identifier,
+                    'title': str(hub.title) if hub.title else PLAYLIST_HUB_TITLES.get(hub_identifier, hub_identifier),
                     'hubIdentifier': str(hub.hubIdentifier) if hub.hubIdentifier else hub_identifier,
                     'source_section_key': section_key,
                     'source_section_title': source_title,
@@ -1767,7 +1732,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
             # Update display to show position for enabled hubs (only with custom config)
             base_title = hub_info.get('title', catalog_id)
-            source_label = hub_info.get('source_section_title', 'Unknown')
+            source_label = hub_info.get('source_section_title', T(32411, 'Unknown'))
 
             if has_custom_config and is_enabled:
                 position = enabled_order[catalog_id]

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -893,6 +893,9 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         # Video hubs - ar16x9
         'video.': 'ar16x9',
         'hub.video.': 'ar16x9',
+        # Playlist hubs
+        'playlists.audio': 'square',
+        'playlists.video': 'ar16x9',
         # Watchlist/discover hubs - always poster (mixed movies + episodes, matches Pannal's original intent)
         'watchlist.': 'poster',
         # Home merged hubs
@@ -1980,7 +1983,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
     def fetchMissingSections(self, section_keys):
         """Trigger background fetch for missing section hubs."""
         # Use sections from sectionList to avoid expensive network call
-        sections_by_key = {None: home_section}
+        sections_by_key = {None: home_section, 'playlists': playlists_section}
         if hasattr(self, 'sectionList') and self.sectionList:
             for mli in self.sectionList:
                 if mli.dataSource and hasattr(mli.dataSource, 'key'):
@@ -3564,11 +3567,14 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         with self.lock:
             # First, find and update the hub in its source section's sectionHubs
             hub_source_section = None
+            # Collect section keys already checked via sectionList
+            checked_keys = set()
             for mli in self.sectionList:
                 section = mli.dataSource
                 if not section:
                     continue
 
+                checked_keys.add(section.key)
                 hubs = self.sectionHubs.get(section.key, ())
                 if not hubs:
                     continue
@@ -3580,6 +3586,20 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                         break
                 if hub_source_section:
                     break
+
+            # If not found, check sectionHubs for hidden sections not in sectionList
+            # (e.g., hidden Playlists section providing cross-section hubs)
+            if not hub_source_section:
+                for section_key, section_hubs in self.sectionHubs.items():
+                    if section_key in checked_keys or not section_hubs:
+                        continue
+                    for idx, ihub in enumerate(section_hubs):
+                        if ihub == hub:
+                            section_hubs[idx] = hub
+                            hub_source_section = True
+                            break
+                    if hub_source_section:
+                        break
 
             if not hub_source_section:
                 util.DEBUG_LOG('Hub {0} not found in any sectionHubs'.format(hub.hubIdentifier))

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -543,7 +543,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         self.closeOption = None
         self.hubControls = None
         self.backgroundSet = False
-        self._homeRefreshTimer = None  # Debounce timer for Home refresh after library callbacks
         self.sectionChangeThread = None
         self.sectionChangeTimeout = 0
         self.lastFocusID = None
@@ -1100,12 +1099,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
         configured_catalog_ids = {h.get('catalog_id', h.get('identifier')) for h in configured_hubs}
 
-        # Build position map for enabled hubs (1-based for display)
-        enabled_positions = {}
-        for idx, hub_config in enumerate(configured_hubs):
-            cat_id = hub_config.get('catalog_id', hub_config.get('identifier'))
-            enabled_positions[cat_id] = idx + 1
-
         # Determine enabled/disabled state for all hubs
         hub_states = {}  # catalog_id -> (is_enabled, hub_info)
         for catalog_id, hub_info in self.availableHubs.items():
@@ -1566,12 +1559,33 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             else:
                 cat_id = '{}:{}'.format(section_key, hub_identifier)
 
-            if cat_id in self.availableHubs:
-                section_config['hubs'].append({
-                    'catalog_id': cat_id,
-                    'identifier': hub_identifier,
-                    'order': len(section_config['hubs'])
-                })
+            section_config['hubs'].append({
+                'catalog_id': cat_id,
+                'identifier': hub_identifier,
+                'order': len(section_config['hubs'])
+            })
+
+            # Backfill availableHubs so _buildHubSettingsOptions can display this hub
+            if cat_id not in self.availableHubs:
+                source_title = 'Home'
+                source_type = 'home'
+                if section_key is not None:
+                    source_section = self.allSections.get(str(section_key))
+                    if source_section:
+                        source_title = str(source_section.title)
+                        source_type = str(source_section.type)
+
+                self.availableHubs[cat_id] = {
+                    'catalog_id': str(cat_id),
+                    'identifier': str(hub_identifier),
+                    'title': str(hub.title) if hub.title else hub_identifier,
+                    'hubIdentifier': str(hub.hubIdentifier) if hub.hubIdentifier else hub_identifier,
+                    'source_section_key': section_key,
+                    'source_section_title': source_title,
+                    'source_section_type': source_type,
+                    'native_display': self.TYPE_TO_DISPLAY.get(hub.items[0].type, 'poster') if hub.items else 'poster',
+                    'item_count': len(hub.items) if hub.items else 0,
+                }
 
         self.saveHubSettings()
         self._hubsSettingsChanged = True
@@ -1989,11 +2003,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                             self._scheduleHomeRefresh()
                         else:
                             self.showHubs(self.lastSection, update=False)
-                    else:
-                        pass
-                else:
-                    pass
-        except Exception as e:
+        except Exception:
             pass
 
     @property
@@ -3478,8 +3488,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             # Check if Home's native hubs are cached
             if self.sectionHubs.get(None) is not None:
                 self.showHubs(self.lastSection, update=False)
-            else:
-                pass
 
     def updateHubCallback(self, hub, items=None, reselect_pos=None):
         with self.lock:

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -782,6 +782,13 @@ class Settings(object):
                     T(33044, "").format(util.addonSettings.hubsRrMax)
                 ),
                 BoolSetting(
+                    'hubs_linear', T(34091, 'Linear Hubs'), False
+                ).description(
+                    T(34092, "Certain hubs, such as Top Unwatched Movies, are randomized by Plex by default, "
+                             "making sequentially consuming content practically impossible. Prevent this and "
+                             "use linearly sorted variants.")
+                ),
+                BoolSetting(
                     'hubs_bifurcation_lines', T(32961, 'Show hub bifurcation lines'), False
                 ).description(
                     T(32962, "Visually separate hubs horizontally using a thin line.")

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3038,3 +3038,11 @@ msgstr ""
 msgctxt "#34093"
 msgid "Refresh Hub List"
 msgstr ""
+
+msgctxt "#34094"
+msgid "Audio Playlists"
+msgstr ""
+
+msgctxt "#34095"
+msgid "Video Playlists"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3034,3 +3034,7 @@ msgstr ""
 msgctxt "#34092"
 msgid "Certain hubs, such as Top Unwatched Movies, are randomized by Plex by default, making sequentially consuming content practically impossible. Prevent this and use linearly sorted variants."
 msgstr ""
+
+msgctxt "#34093"
+msgid "Refresh Hub List"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3026,3 +3026,11 @@ msgstr ""
 msgctxt "#34088"
 msgid "Number of hub rows displayed on the home screen. More rows require more memory."
 msgstr ""
+
+msgctxt "#34091"
+msgid "Linear Hubs"
+msgstr ""
+
+msgctxt "#34092"
+msgid "Certain hubs, such as Top Unwatched Movies, are randomized by Plex by default, making sequentially consuming content practically impossible. Prevent this and use linearly sorted variants."
+msgstr ""


### PR DESCRIPTION
  ### Fixes
  - **Hub config initialization** — all on-screen hubs are now correctly included when first customizing a section's hub
   layout
  - **Cross-section hubs from hidden sections** — Playlists and other sections hidden from the sidebar now work as
  cross-section hub sources, including "load more" pagination
  - **Playlist hub titles** — Audio/Video playlist hubs now show proper titles and correct display types (square/ar16x9)

  ### New features
  - **Linear Hubs** — setting to disable Plex's hub item randomisation
  - **Refresh Hub List** — option in Manage Hubs dialog to re-fetch available hubs without closing

  ### Cleanup
  - Removed unused variables and empty else blocks
  - Added debug logging for hub discovery and Manage Hubs dialog