### PR TITLE
feat: Add genre browser screen for movie/show libraries

### DIFF
--- a/lib/windows/genres.py
+++ b/lib/windows/genres.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import
+
+from plexnet import plexobjects
+
+from lib import util
+from lib.util import T
+from . import kodigui
+from . import opener
+from . import search
+from . import windowutils
+
+
+class GenreBrowserWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
+    xmlFile = 'script-plex-genres.xml'
+    path = util.ADDON.getAddonInfo('path')
+    theme = 'Main'
+    res = '1080i'
+    width = 1920
+    height = 1080
+
+    GENRE_PANEL_ID = 101
+
+    HOME_BUTTON_ID = 201
+    SEARCH_BUTTON_ID = 202
+    PLAYER_STATUS_BUTTON_ID = 204
+
+    def __init__(self, *args, **kwargs):
+        kodigui.ControlledWindow.__init__(self, *args, **kwargs)
+        windowutils.UtilMixin.__init__(self)
+        self.section = kwargs.get('section')
+        self.exitCommand = None
+
+    def onFirstInit(self):
+        self.genreListControl = kodigui.ManagedControlList(self, self.GENRE_PANEL_ID, 5)
+        self.setProperty('screen.title', u'{0} \u00b7 {1}'.format(
+            self.section.title.upper(), T(34080, 'Categories').upper()
+        ))
+        self.fillGenres()
+        self.setBoolProperty('initialized', True)
+        self.setFocusId(self.GENRE_PANEL_ID)
+
+    def fillGenres(self):
+        if self.section.key.startswith('/'):
+            path = '{0}/categories'.format(self.section.key)
+        else:
+            path = '/library/sections/{0}/categories'.format(self.section.key)
+
+        categories = plexobjects.listItems(self.section.server, path, bytag=True)
+        if not categories:
+            return
+
+        items = []
+        for cat in categories:
+            mli = kodigui.ManagedListItem(str(cat.title))
+            mli.dataSource = cat
+            if cat.__dict__.get('thumb'):
+                mli.setThumbnailImage(cat.thumb.asURL(includeToken=True))
+            items.append(mli)
+
+        self.genreListControl.addItems(items)
+        self.setProperty('items.count', str(len(items)))
+
+    def doClose(self, **kw):
+        kodigui.ControlledWindow.doClose(self)
+
+    def onClick(self, controlID):
+        if controlID == self.HOME_BUTTON_ID:
+            self.goHome()
+        elif controlID == self.SEARCH_BUTTON_ID:
+            self.processCommand(search.dialog(self, section_id=self.section.key))
+        elif controlID == self.PLAYER_STATUS_BUTTON_ID:
+            self.showAudioPlayer()
+        elif controlID == self.GENRE_PANEL_ID:
+            self.genreClicked()
+
+    def genreClicked(self):
+        mli = self.genreListControl.getSelectedItem()
+        if not mli or not mli.dataSource:
+            return
+        cat = mli.dataSource
+        # key is e.g. "/library/sections/2/all?genre=5" — extract the numeric genre ID
+        key_str = str(cat.key)
+        genre_id = key_str.split('genre=')[-1].split('&')[0] if 'genre=' in key_str else key_str
+        filter_ = {'type': 'genre', 'display': T(32379, 'Genre'), 'sub': {'val': genre_id, 'display': str(cat.title)}}
+        self.processCommand(opener.sectionClicked(self.section, filter_=filter_))

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -732,6 +732,10 @@ class LibraryWindow(PlaybackBtnMixin, kodigui.MultiWindow, windowutils.UtilMixin
     def searchButtonClicked(self):
         self.processCommand(search.dialog(self, section_id=self.section.key))
 
+    def browseGenres(self):
+        from . import genres as genres_window
+        self.processCommand(opener.handleOpen(genres_window.GenreBrowserWindow, section=self.section))
+
     def keyClicked(self):
         li = self.keyListControl.getSelectedItem()
         if not li:
@@ -818,8 +822,10 @@ class LibraryWindow(PlaybackBtnMixin, kodigui.MultiWindow, windowutils.UtilMixin
             for t in ('show', 'episode', 'collection'):
                 options.append({'type': t, 'display': TYPE_PLURAL.get(t, t)})
         elif self.section.TYPE == 'movie':
-            for t in ('movie', 'collection', 'folder'):
+            for t in ('movie', 'collection'):
                 options.append({'type': t, 'display': TYPE_PLURAL.get(t, t)})
+            options.append({'type': 'browse_genres', 'display': T(34080, 'Categories')})
+            options.append({'type': 'folder', 'display': TYPE_PLURAL.get('folder', 'folder')})
         elif self.section.TYPE == 'artist':
             for t in ('artist', 'album', 'collection', 'track'):
                 options.append({'type': t, 'display': TYPE_PLURAL.get(t, t)})
@@ -842,6 +848,10 @@ class LibraryWindow(PlaybackBtnMixin, kodigui.MultiWindow, windowutils.UtilMixin
             return
 
         choice = result['type']
+
+        if choice == 'browse_genres':
+            self.browseGenres()
+            return
 
         if choice == ITEM_TYPE:
             return

--- a/resources/skins/Main/1080i/templates/script-plex-genres.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-genres.xml.tpl
@@ -1,0 +1,117 @@
+{% extends "library.xml.tpl" %}
+{% block headers %}<defaultcontrol>50</defaultcontrol>{% endblock %}
+
+{% block content %}
+<control type="group" id="50">
+    <visible>!String.IsEmpty(Window.Property(initialized))</visible>
+    <defaultcontrol>101</defaultcontrol>
+    <posx>0</posx>
+    <posy>{{ vscale(135) }}</posy>
+
+    <control type="panel" id="101">
+        <hitrect x="0" y="0" w="1920" h="945" />
+        <posx>0</posx>
+        <posy>0</posy>
+        <width>1920</width>
+        <height>{{ vscale(945) }}</height>
+        <onup>200</onup>
+        <scrolltime>200</scrolltime>
+        <orientation>vertical</orientation>
+        <preloaditems>2</preloaditems>
+
+        <!-- ITEM LAYOUT ########################################## -->
+        <itemlayout width="480" height="{{ vscale(290) }}">
+            <control type="group">
+                <posx>15</posx>
+                <posy>15</posy>
+                <!-- Genre art -->
+                <control type="image">
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>450</width>
+                    <height>{{ vscale(253) }}</height>
+                    <texture background="true">$INFO[ListItem.Thumb]</texture>
+                    <aspectratio>scale</aspectratio>
+                </control>
+                <!-- Dark overlay to make label readable -->
+                <control type="image">
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>450</width>
+                    <height>{{ vscale(253) }}</height>
+                    <texture>script.plex/white-square.png</texture>
+                    <colordiffuse>55000000</colordiffuse>
+                </control>
+                <!-- Genre name -->
+                <control type="label">
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>450</width>
+                    <height>{{ vscale(253) }}</height>
+                    <font>font13</font>
+                    <align>center</align>
+                    <aligny>center</aligny>
+                    <textcolor>FFFFFFFF</textcolor>
+                    <shadowcolor>DD000000</shadowcolor>
+                    <label>$INFO[ListItem.Label]</label>
+                </control>
+            </control>
+        </itemlayout>
+
+        <!-- FOCUSED LAYOUT ####################################### -->
+        <focusedlayout width="480" height="{{ vscale(290) }}">
+            <control type="group">
+                <posx>15</posx>
+                <posy>15</posy>
+                <control type="group">
+                    <animation effect="zoom" start="100" end="105" time="100" center="225,{{ vscale(126) }}" reversible="false">Focus</animation>
+                    <animation effect="zoom" start="105" end="100" time="100" center="225,{{ vscale(126) }}" reversible="false">UnFocus</animation>
+                    <!-- Genre art -->
+                    <control type="image">
+                        <posx>0</posx>
+                        <posy>0</posy>
+                        <width>450</width>
+                        <height>{{ vscale(253) }}</height>
+                        <texture background="true">$INFO[ListItem.Thumb]</texture>
+                        <aspectratio>scale</aspectratio>
+                    </control>
+                    <!-- Dark overlay -->
+                    <control type="image">
+                        <posx>0</posx>
+                        <posy>0</posy>
+                        <width>450</width>
+                        <height>{{ vscale(253) }}</height>
+                        <texture>script.plex/white-square.png</texture>
+                        <colordiffuse>55000000</colordiffuse>
+                    </control>
+                    <!-- Genre name -->
+                    <control type="label">
+                        <scroll>Control.HasFocus(101)</scroll>
+                        <posx>0</posx>
+                        <posy>0</posy>
+                        <width>450</width>
+                        <height>{{ vscale(253) }}</height>
+                        <font>font13</font>
+                        <align>center</align>
+                        <aligny>center</aligny>
+                        <textcolor>FFFFFFFF</textcolor>
+                        <shadowcolor>DD000000</shadowcolor>
+                        <label>$INFO[ListItem.Label]</label>
+                    </control>
+                    <!-- Focus ring -->
+                    <control type="group">
+                        <visible>Control.HasFocus(101)</visible>
+                        <control type="image">
+                            <posx>0</posx>
+                            <posy>0</posy>
+                            <width>460</width>
+                            <height>{{ vscale(263) }}</height>
+                            <texture border="10">script.plex/home/selected.png</texture>
+                        </control>
+                    </control>
+                </control>
+            </control>
+        </focusedlayout>
+    </control>
+</control>
+{% endblock content %}


### PR DESCRIPTION
  Genre Browser

  Adds a genre/category browser screen for movie and TV show libraries.

  What it does

  - Adds a "Categories" option to the library type switcher (the dropdown that shows Movie / Collection / Folder)
  - Opens a new full-screen grid showing all genres for the library, with artwork pulled from Plex's /categories endpoint
  - Clicking a genre filters the library to that genre using the existing filter system

  Changes

  lib/windows/genres.py (new)
  - GenreBrowserWindow — new Kodi window that fetches and displays genre tiles
  - Calls /library/sections/{id}/categories to get genres with artwork
  - On click, extracts the genre ID and delegates to opener.sectionClicked() with a genre filter

  lib/windows/library.py
  - Adds browseGenres() method to LibraryWindow
  - Inserts "Categories" into the type switcher options for movie libraries (between Collection and Folder)
  - Routes browse_genres choice to the new window

  resources/skins/Main/1080i/templates/script-plex-genres.xml.tpl (new)
  - Extends the existing library.xml.tpl base template
  - 4-column panel grid with 16:9 genre art tiles
  - Dark overlay + centred label on each tile for readability
  - Zoom animation on focus, selection ring on focused item
  
  Related to #195