### PR TITLE
Hub refresh fixes, collection sort order, and preplay year labels

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -2003,7 +2003,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             return
 
         str_section_key = str(section_key) if section_key is not None else None
-        refreshed = []
+        tasks_to_add = []
 
         for source_key in required_sources:
             str_source = str(source_key) if source_key is not None else None
@@ -2031,13 +2031,19 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
 
             task = SectionHubsTask().setup(section_obj, self.crossSectionHubsCallback, self.wantedSections)
             self.tasks.append(task)
-            backgroundthread.BGThreader.addTask(task)
-            refreshed.append(str_source)
+            tasks_to_add.append((task, str_source))
 
-        self._pendingCrossSources = len(refreshed)
-        if refreshed:
+        # Set counter BEFORE adding tasks to BGThreader — a fast-completing task
+        # could call crossSectionHubsCallback before we set the counter, leaving
+        # it permanently too high so Home never redraws.
+        self._pendingCrossSources = len(tasks_to_add)
+        for task, _ in tasks_to_add:
+            backgroundthread.BGThreader.addTask(task)
+
+        if tasks_to_add:
             util.DEBUG_LOG('Refreshing cross-section sources for {}: {}',
-                           'Home' if section_key is None else section_key, refreshed)
+                           'Home' if section_key is None else section_key,
+                           [s for _, s in tasks_to_add])
 
     def crossSectionHubsCallback(self, section, hubs, reselect_pos_dict=None):
         """Callback for cross-section hub fetches."""
@@ -2094,7 +2100,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                         else:
                             self.showHubs(self.lastSection, update=False)
         except Exception:
-            pass
+            util.ERROR("Error in crossSectionHubsCallback")
 
     @property
     def currentHub(self):
@@ -2281,9 +2287,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
     def doClose(self, force=True):
         util.DEBUG_LOG("Home: doClose called, triggering close.windows")
         plexapp.util.APP.trigger('close.windows')
-
-        # Cancel any pending Home refresh
-        self._homeRefreshScheduled = 0
 
         #if self.sectionChangeThread and self.sectionChangeThread.isAlive():
         #    self.sectionChangeThread.join(timeout=2.0)
@@ -3504,9 +3507,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
             while self.block_section_change:
                 util.MONITOR.waitFor()
 
-            # Cancel any pending Home refresh when switching sections
-            self._homeRefreshScheduled = 0
-
             self.setProperty('hub.focus', '')
             if util.addonSettings.dynamicBackgrounds:
                 self.backgroundSet = False
@@ -3568,39 +3568,6 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                 if self._pendingLibrarySections == 0 and on_home and has_cross:
                     if self.sectionHubs.get(None) is not None:
                         self.showHubs(self.lastSection, update=False)
-
-    def _scheduleHomeRefresh(self):
-        """Schedule a debounced Home refresh using BGThreader.
-
-        Multiple calls within 0.5s are batched into a single refresh.
-        The task always refreshes after the delay - this avoids a race where
-        a second call updates _homeRefreshScheduled but no new task is created,
-        causing the existing task to skip the refresh entirely.
-        """
-        # Only add task if one isn't already pending
-        if not getattr(self, '_homeRefreshTaskPending', False):
-            self._homeRefreshTaskPending = True
-
-            class HomeRefreshTask(backgroundthread.Task):
-                def setup(task_self, window):
-                    task_self.window = window
-                    return task_self
-
-                def run(task_self):
-                    # Wait a bit for more callbacks to come in
-                    util.MONITOR.waitForAbort(0.5)
-                    task_self.window._homeRefreshTaskPending = False
-                    task_self.window._doHomeRefresh()
-
-            backgroundthread.BGThreader.addTask(HomeRefreshTask().setup(self))
-
-    def _doHomeRefresh(self):
-        """Perform the actual Home refresh."""
-        # Only refresh if still on Home
-        if self.lastSection and self.lastSection.key is None:
-            # Check if Home's native hubs are cached
-            if self.sectionHubs.get(None) is not None:
-                self.showHubs(self.lastSection, update=False)
 
     def updateHubCallback(self, hub, items=None, reselect_pos=None):
         with self.lock:
@@ -4160,6 +4127,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         return self.CREATE_LI_MAP.get(obj.type, self.unhandledHub)(self, obj, wide)
 
     def clearHubs(self):
+        self.updateHubs = {}
         for i, control in enumerate(self.hubControls):
             control.reset()
             # Clear display type property for this hub slot

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -839,6 +839,24 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
         collections = self.video.collections() if self.video.type == 'movie' and self.video.collections else []
         section_id = self.video.getLibrarySectionId()
 
+        # Fetch the section's collection metadata items to get their proper keys,
+        # which respect the sort order set in Plex (Custom / Alphabetical / Release Date).
+        # The id on a movie's <Collection> tag is a tag ID, not a metadata ratingKey,
+        # so we can't use it directly — match by title instead.
+        col_key_map = {}  # title → key (e.g. "/library/metadata/12345/children")
+        try:
+            col_items = plexobjects.listItems(
+                self.video.server,
+                '/library/sections/{0}/collections'.format(section_id)
+            )
+            for col_item in col_items:
+                title = str(col_item.title)
+                key = str(col_item.key)
+                if title and key:
+                    col_key_map[title] = key
+        except Exception:
+            util.ERROR()
+
         for i, list_control in enumerate(self.collectionListControls):
             if i >= len(collections):
                 list_control.reset()
@@ -847,7 +865,13 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin, RatingsMixi
                 continue
 
             collection = collections[i]
-            path = '/library/sections/{0}/all?type=1&{1}'.format(section_id, collection.filter)
+            tag = str(collection.tag)
+            if tag in col_key_map:
+                path = col_key_map[tag]
+            else:
+                # Fallback: filter-based path. Works but ignores custom sort order.
+                path = '/library/sections/{0}/all?type=1&{1}'.format(section_id, collection.filter)
+
             paginator = CollectionPaginator(list_control, parent_window=self, leaf_count=0)
             paginator.setup(self.video.server, path)
             try:

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -35,6 +35,14 @@ class RelatedPaginator(pagination.BaseRelatedPaginator):
     def getData(self, offset, amount):
         return self.parentWindow.video.getRelated(offset=offset, limit=amount)
 
+    def createListItem(self, rel):
+        return kodigui.ManagedListItem(
+            rel.title or '',
+            str(rel.year) if rel.year else '',
+            thumbnailImage=rel.defaultThumb.asTranscodedImageURL(*self.parentWindow.RELATED_DIM),
+            data_source=rel
+        )
+
 
 class CollectionPaginator(pagination.BaseRelatedPaginator):
     initialPageSize = 10
@@ -64,6 +72,7 @@ class CollectionPaginator(pagination.BaseRelatedPaginator):
     def createListItem(self, item):
         return kodigui.ManagedListItem(
             item.title or '',
+            str(item.year) if item.year else '',
             thumbnailImage=item.defaultThumb.asTranscodedImageURL(*self.parentWindow.RELATED_DIM),
             data_source=item
         )

--- a/resources/skins/Main/1080i/templates/script-plex-home.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-home.xml.tpl
@@ -560,7 +560,7 @@
                 </control>
                 <control type="group">
                     <visible>Control.HasFocus(260) | !String.IsEmpty(Window.Property(show.servers))</visible>
-                    <posx>-413</posx>
+                    <posx>-250</posx>
                     <posy>{{ vscale(70) }}</posy>
                     <control type="image" id="800">
                         <posx>-40</posx>
@@ -570,7 +570,7 @@
                         <texture border="42">script.plex/drop-shadow.png</texture>
                     </control>
                     <control type="image">
-                        <posx>432</posx>
+                        <posx>269</posx>
                         <posy>{{ vscale(-13) }}</posy>
                         <width>15</width>
                         <height>{{ vscale(13) }}</height>

--- a/resources/skins/Main/1080i/templates/script-plex-pre_play.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-pre_play.xml.tpl
@@ -923,7 +923,7 @@
             <visible>Integer.IsGreater(Container(403).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>403</defaultcontrol>
             <width>1920</width>
-            <height>{{ vscale(520) }}</height>
+            <height>{{ vscale(555) }}</height>
             <control type="label">
                 <posx>60</posx>
                 <posy>0</posy>
@@ -939,7 +939,7 @@
                 <posx>0</posx>
                 <posy>{{ vscale(16) }}</posy>
                 <width>1920</width>
-                <height>{{ vscale(520) }}</height>
+                <height>{{ vscale(555) }}</height>
                 <onup>402</onup>
                 <ondown>404</ondown>
                 <onleft>noop</onleft>
@@ -1003,6 +1003,18 @@
                                 <align>center</align>
                                 <textcolor>FFFFFFFF</textcolor>
                                 <label>$INFO[ListItem.Label]</label>
+                            </control>
+                            <control type="label">
+                                <scroll>false</scroll>
+                                <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                <posx>0</posx>
+                                <posy>{{ vscale(398) }}</posy>
+                                <width>244</width>
+                                <height>{{ vscale(35) }}</height>
+                                <font>font10</font>
+                                <align>center</align>
+                                <textcolor>99FFFFFF</textcolor>
+                                <label>$INFO[ListItem.Label2]</label>
                             </control>
                             <control type="group">
                                 <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
@@ -1112,6 +1124,18 @@
                                     <textcolor>FFFFFFFF</textcolor>
                                     <label>$INFO[ListItem.Label]</label>
                                 </control>
+                                <control type="label">
+                                    <scroll>Control.HasFocus(403)</scroll>
+                                    <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(398) }}</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(35) }}</height>
+                                    <font>font10</font>
+                                    <align>center</align>
+                                    <textcolor>99FFFFFF</textcolor>
+                                    <label>$INFO[ListItem.Label2]</label>
+                                </control>
                             </control>
                             <control type="image">
                                 <visible>Control.HasFocus(403)</visible>
@@ -1167,7 +1191,7 @@
             <visible>Integer.IsGreater(Container(404).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>404</defaultcontrol>
             <width>1920</width>
-            <height>{{ vscale(520) }}</height>
+            <height>{{ vscale(555) }}</height>
             <control type="label">
                 <posx>60</posx>
                 <posy>0</posy>
@@ -1183,7 +1207,7 @@
                 <posx>0</posx>
                 <posy>{{ vscale(16) }}</posy>
                 <width>1920</width>
-                <height>{{ vscale(520) }}</height>
+                <height>{{ vscale(555) }}</height>
                 <onup>403</onup>
                 <ondown>405</ondown>
                 <onleft>noop</onleft>
@@ -1245,6 +1269,18 @@
                                 <align>center</align>
                                 <textcolor>FFFFFFFF</textcolor>
                                 <label>$INFO[ListItem.Label]</label>
+                            </control>
+                            <control type="label">
+                                <scroll>false</scroll>
+                                <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                <posx>0</posx>
+                                <posy>{{ vscale(398) }}</posy>
+                                <width>244</width>
+                                <height>{{ vscale(35) }}</height>
+                                <font>font10</font>
+                                <align>center</align>
+                                <textcolor>99FFFFFF</textcolor>
+                                <label>$INFO[ListItem.Label2]</label>
                             </control>
                             <control type="group">
                                 <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
@@ -1351,6 +1387,18 @@
                                     <textcolor>FFFFFFFF</textcolor>
                                     <label>$INFO[ListItem.Label]</label>
                                 </control>
+                                <control type="label">
+                                    <scroll>Control.HasFocus(404)</scroll>
+                                    <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(398) }}</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(35) }}</height>
+                                    <font>font10</font>
+                                    <align>center</align>
+                                    <textcolor>99FFFFFF</textcolor>
+                                    <label>$INFO[ListItem.Label2]</label>
+                                </control>
                             </control>
                             <control type="image">
                                 <visible>Control.HasFocus(404)</visible>
@@ -1406,7 +1454,7 @@
             <visible>Integer.IsGreater(Container(405).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>405</defaultcontrol>
             <width>1920</width>
-            <height>{{ vscale(520) }}</height>
+            <height>{{ vscale(555) }}</height>
             <control type="label">
                 <posx>60</posx>
                 <posy>0</posy>
@@ -1422,7 +1470,7 @@
                 <posx>0</posx>
                 <posy>{{ vscale(16) }}</posy>
                 <width>1920</width>
-                <height>{{ vscale(520) }}</height>
+                <height>{{ vscale(555) }}</height>
                 <onup>404</onup>
                 <ondown>406</ondown>
                 <onleft>noop</onleft>
@@ -1484,6 +1532,18 @@
                                 <align>center</align>
                                 <textcolor>FFFFFFFF</textcolor>
                                 <label>$INFO[ListItem.Label]</label>
+                            </control>
+                            <control type="label">
+                                <scroll>false</scroll>
+                                <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                <posx>0</posx>
+                                <posy>{{ vscale(398) }}</posy>
+                                <width>244</width>
+                                <height>{{ vscale(35) }}</height>
+                                <font>font10</font>
+                                <align>center</align>
+                                <textcolor>99FFFFFF</textcolor>
+                                <label>$INFO[ListItem.Label2]</label>
                             </control>
                             <control type="group">
                                 <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
@@ -1590,6 +1650,18 @@
                                     <textcolor>FFFFFFFF</textcolor>
                                     <label>$INFO[ListItem.Label]</label>
                                 </control>
+                                <control type="label">
+                                    <scroll>Control.HasFocus(405)</scroll>
+                                    <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(398) }}</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(35) }}</height>
+                                    <font>font10</font>
+                                    <align>center</align>
+                                    <textcolor>99FFFFFF</textcolor>
+                                    <label>$INFO[ListItem.Label2]</label>
+                                </control>
                             </control>
                             <control type="image">
                                 <visible>Control.HasFocus(405)</visible>
@@ -1645,7 +1717,7 @@
             <visible>Integer.IsGreater(Container(406).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>406</defaultcontrol>
             <width>1920</width>
-            <height>{{ vscale(520) }}</height>
+            <height>{{ vscale(555) }}</height>
             <control type="label">
                 <posx>60</posx>
                 <posy>0</posy>
@@ -1661,7 +1733,7 @@
                 <posx>0</posx>
                 <posy>{{ vscale(16) }}</posy>
                 <width>1920</width>
-                <height>{{ vscale(520) }}</height>
+                <height>{{ vscale(555) }}</height>
                 <onup>405</onup>
                 <onleft>noop</onleft>
                 <onright>noop</onright>
@@ -1722,6 +1794,18 @@
                                 <align>center</align>
                                 <textcolor>FFFFFFFF</textcolor>
                                 <label>$INFO[ListItem.Label]</label>
+                            </control>
+                            <control type="label">
+                                <scroll>false</scroll>
+                                <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                <posx>0</posx>
+                                <posy>{{ vscale(398) }}</posy>
+                                <width>244</width>
+                                <height>{{ vscale(35) }}</height>
+                                <font>font10</font>
+                                <align>center</align>
+                                <textcolor>99FFFFFF</textcolor>
+                                <label>$INFO[ListItem.Label2]</label>
                             </control>
                             <control type="group">
                                 <visible>!String.IsEmpty(ListItem.Property(is.boundary))</visible>
@@ -1827,6 +1911,18 @@
                                     <align>center</align>
                                     <textcolor>FFFFFFFF</textcolor>
                                     <label>$INFO[ListItem.Label]</label>
+                                </control>
+                                <control type="label">
+                                    <scroll>Control.HasFocus(406)</scroll>
+                                    <visible>!String.IsEmpty(ListItem.Label2)</visible>
+                                    <posx>0</posx>
+                                    <posy>{{ vscale(398) }}</posy>
+                                    <width>244</width>
+                                    <height>{{ vscale(35) }}</height>
+                                    <font>font10</font>
+                                    <align>center</align>
+                                    <textcolor>99FFFFFF</textcolor>
+                                    <label>$INFO[ListItem.Label2]</label>
                                 </control>
                             </control>
                             <control type="image">


### PR DESCRIPTION
  A collection of bug fixes across the hub refresh system and movie preplay screen.

  ### Hub refresh race condition (`home.py`)
  `_pendingCrossSources` counter is now set **before** tasks are added to `BGThreader`, preventing a fast-completing task from firing its callback before the counter is initialised — which previously left Home
   permanently stuck without redrawing. Removes dead `_scheduleHomeRefresh` debounce code, silenced exceptions now logged via `util.ERROR()`, and `clearHubs()` resets `updateHubs` to prevent stale state on
  section switches.

  ### Collection sort order on preplay screen (`preplay.py`)
  Collection hub rows now respect the sort order set in Plex. Previously the filter path (`/all?type=1&collection=...`) ignored custom sort. Now fetches `/library/sections/{id}/collections` to map collection
  titles to their metadata keys, using the key path which honours Plex sort order. Filter path kept as fallback.

  ### Year labels on Related and Collection hubs (`preplay.py`, `script-plex-pre_play.xml.tpl`)
  Release year now shown beneath each title in the Related and Collection hub rows on the preplay screen. Hub row height increased from 520 → 555px to accommodate the extra line.

  ### Server dropdown clipping (`script-plex-home.xml.tpl`)
  Server switcher dropdown was clipped off-screen with long usernames. Fixed horizontal offsets so it always appears flush with the button.