### PR TITLE
Actor/Director screen: fix scroll animation, header visibility, and visual blip

### DIFF
--- a/lib/windows/person.py
+++ b/lib/windows/person.py
@@ -167,6 +167,7 @@ class PersonWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
     def __init__(self, *args, **kwargs):
         kodigui.ControlledWindow.__init__(self, *args, **kwargs)
+        self.setProperty('loading', '1')
         self.role = kwargs.get('role')
         self.personDetails = None
         self.filmographyItems = []
@@ -184,6 +185,7 @@ class PersonWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.initialized = False
 
     def onFirstInit(self):
+        self.setProperty('loading', '1')
         self.filmographyListControl = kodigui.ManagedControlList(self, self.FILMOGRAPHY_LIST_ID, 5)
 
         self.discoverListControls = []
@@ -258,6 +260,11 @@ class PersonWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
     def onFocus(self, controlID):
         if self.FILMOGRAPHY_LIST_ID <= controlID <= self.DISCOVER_LIST_BASE_ID + DISCOVER_HUB_SLOTS:
             self.setProperty('hub.focus', str(controlID - self.FILMOGRAPHY_LIST_ID))
+
+        if controlID > self.FILMOGRAPHY_LIST_ID:
+            self.setProperty('on.extras', '1')
+        else:
+            self.setProperty('on.extras', '')
 
     def doClose(self, **kw):
         self.tasks.kill()

--- a/resources/skins/Main/1080i/templates/script-plex-person.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-person.xml.tpl
@@ -1,5 +1,6 @@
 {% extends "default.xml.tpl" %}
 {% block headers %}<defaultcontrol>400</defaultcontrol>{% endblock %}
+{% block header_anim %}<animation effect="slide" end="0,{{ vscale(-135) }}" time="200" tween="sine" easing="inout" condition="!String.IsEmpty(Window.Property(on.extras)) + !ControlGroup(200).HasFocus(0)">Conditional</animation>{% endblock %}
 
 {% block content %}
 <!-- Background -->
@@ -29,7 +30,7 @@
     {% for i in range(6) %}
     {% with check_group = i + 501 %}
     <animation type="Conditional" condition="Integer.IsGreater(Window.Property(hub.focus),{{ i }}) + Control.IsVisible({{ check_group }})" reversible="true">
-        <effect type="slide" end="0,{{ vscale(-540) }}" time="300" tween="quadratic" easing="out"/>
+        <effect type="slide" end="0,{{ vscale(-540) }}" time="200" tween="sine" easing="inout"/>
     </animation>
     {% endwith %}
     {% endfor %}


### PR DESCRIPTION
  1. Scroll animation inconsistency
  Changed from quadratic/out at 300ms to sine/inout at 200ms to match the home screen.

  2. Home/search icons staying visible when scrolling
  on.extras was never being set so the header never hid. Now hides (matching home's -135px/sine/inout animation) when a
  discover hub is focused and content is physically sliding. Stays visible when only the filmography list is focused to
  avoid buttons disappearing without any content movement.

  3. Visual blip on opening
  "Movies & Shows in Media Libraries" and the filter button were briefly visible before content loaded. Kodi renders a
  frame before onFirstInit runs, so loading was empty on first render. Fixed by setting loading='1' in __init__ instead.