### PR TITLE
fix: Correct string ID conflict and add Categories to TV show libraries

### DIFF
--- a/lib/windows/genres.py
+++ b/lib/windows/genres.py
@@ -33,7 +33,7 @@ class GenreBrowserWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
     def onFirstInit(self):
         self.genreListControl = kodigui.ManagedControlList(self, self.GENRE_PANEL_ID, 5)
         self.setProperty('screen.title', u'{0} \u00b7 {1}'.format(
-            self.section.title.upper(), T(34080, 'Categories').upper()
+            self.section.title.upper(), T(34102, 'Categories').upper()
         ))
         self.fillGenres()
         self.setBoolProperty('initialized', True)

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -821,10 +821,11 @@ class LibraryWindow(PlaybackBtnMixin, kodigui.MultiWindow, windowutils.UtilMixin
         if self.section.TYPE == 'show':
             for t in ('show', 'episode', 'collection'):
                 options.append({'type': t, 'display': TYPE_PLURAL.get(t, t)})
+            options.append({'type': 'browse_genres', 'display': T(34102, 'Categories')})
         elif self.section.TYPE == 'movie':
             for t in ('movie', 'collection'):
                 options.append({'type': t, 'display': TYPE_PLURAL.get(t, t)})
-            options.append({'type': 'browse_genres', 'display': T(34080, 'Categories')})
+            options.append({'type': 'browse_genres', 'display': T(34102, 'Categories')})
             options.append({'type': 'folder', 'display': TYPE_PLURAL.get('folder', 'folder')})
         elif self.section.TYPE == 'artist':
             for t in ('artist', 'album', 'collection', 'track'):

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3120,7 +3120,11 @@ msgctxt "#34101"
 msgid "Re-test server connection reachability every 10 minutes to detect network changes (e.g. WiFi to mobile). Useful on mobile devices. Default: Off"
 msgstr ""
 
-# Unused: 34102-35000 (899 IDs)
+msgctxt "#34102"
+msgid "Categories"
+msgstr ""
+
+# Unused: 34103-35000 (898 IDs)
 
 msgctxt "#32473"
 msgid "Actor"


### PR DESCRIPTION
- Assign new string ID 34102 for 'Categories' (34080 was already used for 'Manage Hubs' in the dynamic hubs feature, causing the dropdown and screen title to show the wrong label after rebase)
- Add Categories entry to the TV show library type dropdown, matching the existing movie library behaviour
