### PR TITLE
Episodes: Interleave specials into series queue by air date (opt-in)

### DIFF
--- a/lib/_included_packages/plexnet/playlist.py
+++ b/lib/_included_packages/plexnet/playlist.py
@@ -186,3 +186,52 @@ class LocalPlaylist(BasePlaylist):
         if not self._mediaItem:
             return super(LocalPlaylist, self).defaultArt
         return self._mediaItem.defaultArt
+
+
+def reorder_with_specials(episodes, mode='default'):
+    """
+    Reorder a flat episode list so specials (parentIndex == 0) land correctly.
+
+    Modes:
+      'default'    - return episodes unchanged (PMS allLeaves order: specials first).
+                     Note: getNextShowEp() will still skip past specials when picking
+                     the starting episode, so specials remain in the queue but won't
+                     play in this session - this preserves long-standing PM4K behaviour.
+      'interleave' - regulars by (season, episode), each special inserted before
+                     the first regular with a later originallyAvailableAt;
+                     undated specials appended at the end
+    """
+    if mode == 'default' or not episodes:
+        return episodes
+
+    regulars = [e for e in episodes if e.parentIndex.asInt() != 0]
+    specials = [e for e in episodes if e.parentIndex.asInt() == 0]
+
+    if not specials:
+        return episodes
+
+    regulars.sort(key=lambda e: (e.parentIndex.asInt(), e.index.asInt()))
+    specials.sort(key=lambda e: e.index.asInt())
+
+    if not regulars:
+        return specials
+
+    result = list(regulars)
+    leftover = []
+    for special in specials:
+        sd = special.originallyAvailableAt.asDatetime()
+        if sd is None:
+            leftover.append(special)
+            continue
+
+        inserted = False
+        for i, reg in enumerate(result):
+            reg_d = reg.originallyAvailableAt.asDatetime()
+            if reg_d is not None and reg_d > sd:
+                result.insert(i, special)
+                inserted = True
+                break
+        if not inserted:
+            leftover.append(special)
+
+    return result + leftover

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -1144,7 +1144,11 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMix
         if not from_auto_play:
             self.playBtnClicked = True
 
-        pl = playlist.LocalPlaylist(self.show_.all(), self.show_.getServer())
+        items = playlist.reorder_with_specials(
+            self.show_.all(),
+            mode=util.getSetting('tv_specials_order', 'default')
+        )
+        pl = playlist.LocalPlaylist(items, self.show_.getServer())
         try:
             # inject our show in case we need to access show metadata from the player
             episode._show = self.show_

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -977,6 +977,21 @@ class Settings(object):
                              '\nCan be disabled/enabled per TV show. Doesn\'t override enabled binge mode. '
                              'Overrides the Post Play setting.')
                 ),
+                OptionsSetting(
+                    'tv_specials_order',
+                    T(34103, 'Specials in episode queue'),
+                    'default',
+                    (
+                        ('default', T(34105, 'Library default')),
+                        ('interleave', T(34107, 'Interleave by air date')),
+                    )
+                ).description(
+                    T(34104, "Library default keeps Plex's order in the queue, with specials at the "
+                             "front - playback skips past them and starts at the first regular episode, "
+                             "so they appear in the queue but won't play. "
+                             "Interleave inserts each special by its original air date and plays them "
+                             "between regular episodes.")
+                ),
             )
         ),
         'network': (

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -499,6 +499,10 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMixin, 
             return
 
         items = self.mediaItem.all(unwatched=True)
+        if not shuffle and self.mediaItem.type == 'show':
+            items = playlist.reorder_with_specials(
+                items, mode=util.getSetting('tv_specials_order', 'default')
+            )
         pl = playlist.LocalPlaylist(items, self.mediaItem.getServer())
         resume = False
         if not shuffle and self.mediaItem.type == 'show':

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3128,7 +3128,23 @@ msgctxt "#34102"
 msgid "Categories"
 msgstr ""
 
-# Unused: 34103-35000 (898 IDs)
+msgctxt "#34103"
+msgid "Specials in episode queue"
+msgstr ""
+
+msgctxt "#34104"
+msgid "Library default keeps Plex's order in the queue, with specials at the front - playback skips past them and starts at the first regular episode, so they appear in the queue but won't play. Interleave inserts each special by its original air date and plays them between regular episodes."
+msgstr ""
+
+msgctxt "#34105"
+msgid "Library default"
+msgstr ""
+
+msgctxt "#34107"
+msgid "Interleave by air date"
+msgstr ""
+
+# Unused: 34106, 34108-35000 (894 IDs)
 
 msgctxt "#32473"
 msgid "Actor"


### PR DESCRIPTION
When playing a show, episodes returned by /library/metadata/{id}/allLeaves are ordered by parentIndex+index, placing season 0 (specials) at the front of the queue regardless of when they actually aired. PMS only interleaves correctly when TVDB has airsBeforeSeason/airsBeforeEpisode populated; for shows with sparse metadata (anime in particular) even Plex web shows specials first.

Adds a client-side reorder pass in playlist.reorder_with_specials() called from both LocalPlaylist construction paths:

  - episodes.py:1146 (play from the episodes screen)
  - subitems.py:497  (play from the show overview)

New user setting tv_specials_order (Settings > Player), default 'default' to preserve long-standing PM4K behaviour:

  default    - PMS order (specials first in queue). getNextShowEp
               still skips past them when picking the starting
               episode, so specials appear in the queue but don't
               play this session - matches historical behaviour.
  interleave - regulars by (season, episode); each special inserted
               before the first regular with a later originallyAvail
               ableAt. Undated specials appended at end. Playback
               walks the queue in order so specials play between
               regular episodes (e.g. between S1 and S2).

Shuffle path is intentionally untouched - shuffle randomises anyway. Setting is gated to type == 'show' on the subitems.py callsite to avoid affecting artist windows.

New strings 34103, 34104, 34105, 34107 in strings.po.

solves: #253
