### PR TITLE
Home: optional setting to disable exit-on-Back

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -2521,6 +2521,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                         return
 
                 if action in (xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU) and not self._checkingForExit:
+                    if util.getSetting('disable_exit_on_back', False):
+                        return
                     try:
                         self._checkingForExit = True
                         if self._shuttingDown:

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -773,6 +773,13 @@ class Settings(object):
                              "watching etc., show a confirmation dialog.")
                 ),
                 BoolSetting(
+                    'disable_exit_on_back', T(35007, 'Home: Disable exit on Back'), False
+                ).description(
+                    T(35008, "When enabled, pressing Back on the Home screen no longer shows the "
+                             "exit prompt and will not exit Plex. You can still exit from the Exit "
+                             "option in your username menu.")
+                ),
+                BoolSetting(
                     'hub_season_thumbnails', T(33740, 'Home: Episodes season thumbnails'), True
                 ).description(
                     T(33741, "Use season thumbnails/posters when displaying episodes in hubs instead of "

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3161,3 +3161,11 @@ msgstr ""
 msgctxt "#34091"
 msgid "Choose Version"
 msgstr ""
+
+msgctxt "#35007"
+msgid "Home: Disable exit on Back"
+msgstr ""
+
+msgctxt "#35008"
+msgid "When enabled, pressing Back on the Home screen no longer shows the exit prompt and will not exit Plex. You can still exit from the Exit option in your username menu."
+msgstr ""


### PR DESCRIPTION
  ## Summary
  Adds an opt-in setting, **"Home: Disable exit on Back"** (default off), that stops the
  Back button on the Home screen from exiting PM4K. With it enabled, Back on Home is a
  no-op — no exit confirmation and no exit — which avoids accidentally quitting the app.
  Deliberate exit via the **Exit** entry in the username menu is unaffected.

  ## Behaviour
  - **Off (default):** unchanged — Back on Home shows the usual Exit / Minimize / Cancel prompt.
  - **On:** Back on Home does nothing (you stay on Home).
  - Either way, the username-menu **Exit** still quits the app.

  ## Changes
  - `lib/windows/settings.py` — new `disable_exit_on_back` `BoolSetting` (default `False`),
    placed next to "Home: Confirm item actions".
  - `lib/windows/home.py` — early `return` in the Home Back handler when the setting is on,
    before the exit-confirmation flow (the only path affected).
  - `strings.po` — label + description (#35007 / #35008).