### PR TITLE
feat: shuffle library mode (per-library shuffle with playback modes)

### DIFF
--- a/lib/shuffle.py
+++ b/lib/shuffle.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+import random
+
+# Shuffle Mode identifiers (also used as dropdown choice keys in library.py)
+MODE_UNWATCHED = 'unwatched'   # never-started shows, play from the start
+MODE_REWATCH = 'rewatch'       # fully-watched shows, play from the start
+MODE_CATCHUP = 'catchup'       # started shows with few unwatched episodes left
+
+
+def _as_int(value):
+    """Accept plexnet PlexValue (has .asInt()) or a plain int/str."""
+    as_int = getattr(value, 'asInt', None)
+    if callable(as_int):
+        return as_int()
+    return int(value)
+
+
+def eligible_shows(shows, mode, threshold=None):
+    """Filter `shows` (objects exposing leafCount/viewedLeafCount) to those
+    eligible for `mode`. Shows with no episodes are always skipped."""
+    result = []
+    for show in shows:
+        total = _as_int(show.leafCount)
+        if total <= 0:
+            continue
+        viewed = _as_int(show.viewedLeafCount)
+        unviewed = total - viewed
+
+        if mode == MODE_UNWATCHED:
+            if viewed == 0:
+                result.append(show)
+        elif mode == MODE_REWATCH:
+            if unviewed == 0:
+                result.append(show)
+        elif mode == MODE_CATCHUP:
+            if viewed > 0 and 0 < unviewed <= threshold:
+                result.append(show)
+    return result
+
+
+def pick(shows, count, rng=random):
+    """Return up to `count` shows chosen at random (shuffled). If the pool is
+    smaller than `count`, return the whole pool shuffled."""
+    pool = list(shows)
+    if count >= len(pool):
+        rng.shuffle(pool)
+        return pool
+    return rng.sample(pool, count)
+
+
+def unwatched_episodes(episodes):
+    """Keep only episodes that have not been watched."""
+    return [ep for ep in episodes if not bool(ep.isWatched)]
+
+
+def first_regular_index(episodes):
+    """Index of the first non-special episode (parentIndex != 0), else 0.
+    Used to start playback on a real episode rather than a leading special."""
+    for i, ep in enumerate(episodes):
+        if _as_int(ep.parentIndex) != 0:
+            return i
+    return 0
+
+
+def eligible_movies(movies, mode):
+    """Filter `movies` (objects exposing isWatched) for a movie shuffle mode:
+    MODE_UNWATCHED -> unseen movies; MODE_REWATCH -> already-watched movies."""
+    if mode == MODE_REWATCH:
+        return [m for m in movies if bool(m.isWatched)]
+    if mode == MODE_UNWATCHED:
+        return [m for m in movies if not bool(m.isWatched)]
+    return list(movies)

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -13,6 +13,7 @@ import six.moves.urllib.request
 from kodi_six import xbmc
 from kodi_six import xbmcgui
 from plexnet import playqueue
+from plexnet import playlist
 from plexnet import plexobjects
 from plexnet import util as pnUtil
 from six.moves import range
@@ -20,11 +21,13 @@ from six.moves import range
 from lib import backgroundthread
 from lib import player
 from lib import util
+from lib import shuffle
 from lib.util import T
 from . import busy
 from . import dropdown
 from . import kodigui
 from . import opener
+from . import videoplayer
 from . import optionsdialog
 from . import preplay
 from . import search
@@ -827,7 +830,116 @@ class LibraryWindow(PlaybackBtnMixin, kodigui.MultiWindow, windowutils.UtilMixin
         opener.open(pq, auto_play=True, auto_play_open=True)
 
     def shuffleButtonClicked(self):
-        self.playButtonClicked(shuffle=True)
+        # TV and movie libraries open the Shuffle Mode menu; other section types
+        # keep the classic server-side random shuffle.
+        if self.section.TYPE == 'show':
+            self.shuffleModeSelected()
+        elif self.section.TYPE == 'movie':
+            self.movieShuffleSelected()
+        else:
+            self.playButtonClicked(shuffle=True)
+
+    def movieShuffleSelected(self):
+        options = [
+            {'key': shuffle.MODE_UNWATCHED, 'display': T(35010, "Unwatched")},
+            {'key': shuffle.MODE_REWATCH, 'display': T(35011, "Rewatch")},
+            {'key': 'classic', 'display': T(35018, "Shuffle All")},
+        ]
+        choice = dropdown.showDropdown(
+            options,
+            pos=(660, 441),
+            close_direction='none',
+            set_dropdown_prop=False,
+            header=T(35009, "Shuffle Mode"),
+            select_index=0,
+            align_items="left",
+        )
+        if not choice:
+            return
+        if choice['key'] == 'classic':
+            self.playButtonClicked(shuffle=True)
+            return
+        self.startMovieShuffle(choice['key'])
+
+    def startMovieShuffle(self, mode):
+        with busy.BusyContext(delay=True, delay_time=0.2):
+            movies = self.section.all(type_=1)
+            pool = shuffle.eligible_movies(movies, mode)
+            if not pool:
+                util.messageDialog(T(35009, "Shuffle Mode"),
+                                   T(35013, "No matching items are available for this shuffle mode."))
+                return
+            ordered = shuffle.pick(pool, len(pool))
+
+        pl = playlist.LocalPlaylist(ordered, self.section.getServer())
+        self.processCommand(videoplayer.play(play_queue=pl))
+
+    def shuffleModeSelected(self):
+        options = [
+            {'key': shuffle.MODE_UNWATCHED, 'display': T(35010, "Unwatched")},
+            {'key': shuffle.MODE_REWATCH, 'display': T(35011, "Rewatch")},
+            {'key': shuffle.MODE_CATCHUP, 'display': T(35012, "Catchup")},
+            {'key': 'classic', 'display': T(35018, "Shuffle All")},
+        ]
+        choice = dropdown.showDropdown(
+            options,
+            pos=(660, 441),
+            close_direction='none',
+            set_dropdown_prop=False,
+            header=T(35009, "Shuffle Mode"),
+            select_index=0,
+            align_items="left",
+        )
+        if not choice:
+            return
+        if choice['key'] == 'classic':
+            self.playButtonClicked(shuffle=True)
+            return
+        self.startShuffleMode(choice['key'])
+
+    def startShuffleMode(self, mode):
+        section = self.section
+        threshold = util.getSetting('shuffle_catchup_episode_threshold', 3)
+        series_count = util.getSetting('shuffle_catchup_series_count', 5)
+        specials_mode = util.getSetting('tv_specials_order', 'default')
+
+        items = []
+        with busy.BusyContext(delay=True, delay_time=0.2):
+            shows = section.all(type_=2)
+            pool = shuffle.eligible_shows(shows, mode, threshold=threshold)
+            if not pool:
+                util.messageDialog(T(35009, "Shuffle Mode"),
+                                   T(35013, "No shows are available for this shuffle mode."))
+                return
+
+            pick_count = series_count if mode == shuffle.MODE_CATCHUP else 1
+            start_index = 0
+            for show in shuffle.pick(pool, pick_count):
+                episodes = show.all()
+                if mode == shuffle.MODE_CATCHUP:
+                    # Eligibility counts PMS viewedLeafCount (fully-watched leaves only),
+                    # so in-progress episodes are dropped here and a show may contribute
+                    # fewer episodes than its unwatched count implied. The empty-queue
+                    # guard below handles the case where nothing is left to play.
+                    episodes = shuffle.unwatched_episodes(episodes)
+                episodes = playlist.reorder_with_specials(episodes, mode=specials_mode)
+                for ep in episodes:
+                    # let the player reach show metadata, mirroring episodes.py
+                    ep._show = show
+                if not items:
+                    # first show that actually contributes: start on its own first real
+                    # episode (skip a leading special), not somewhere later in the queue
+                    start_index = shuffle.first_regular_index(episodes)
+                items.extend(episodes)
+
+        if not items:
+            util.messageDialog(T(35009, "Shuffle Mode"),
+                               T(35013, "No shows are available for this shuffle mode."))
+            return
+
+        pl = playlist.LocalPlaylist(items, section.getServer())
+        pl.setCurrent(items[start_index])
+        self.processCommand(videoplayer.play(play_queue=pl))
 
     def optionsButtonClicked(self):
         options = []

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -999,6 +999,18 @@ class Settings(object):
                              "Interleave inserts each special by its original air date and plays them "
                              "between regular episodes.")
                 ),
+                IntegerSetting(
+                    'shuffle_catchup_series_count', T(35014, 'Shuffle Catchup: number of series'), 5
+                ).description(
+                    T(35015, 'How many series to queue in Catchup shuffle mode.')
+                ),
+                IntegerSetting(
+                    'shuffle_catchup_episode_threshold',
+                    T(35016, 'Shuffle Catchup: max unwatched episodes per series'), 3
+                ).description(
+                    T(35017, 'Only include a series in Catchup mode when it has this many or fewer '
+                             'unwatched episodes left.')
+                ),
             )
         ),
         'network': (

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3193,3 +3193,43 @@ msgstr ""
 msgctxt "#35008"
 msgid "When enabled, pressing Back on the Home screen no longer shows the exit prompt and will not exit Plex. You can still exit from the Exit option in your username menu."
 msgstr ""
+
+msgctxt "#35009"
+msgid "Shuffle Mode"
+msgstr ""
+
+msgctxt "#35010"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#35011"
+msgid "Rewatch"
+msgstr ""
+
+msgctxt "#35012"
+msgid "Catchup"
+msgstr ""
+
+msgctxt "#35013"
+msgid "No matching items are available for this shuffle mode."
+msgstr ""
+
+msgctxt "#35014"
+msgid "Shuffle Catchup: number of series"
+msgstr ""
+
+msgctxt "#35015"
+msgid "How many series to queue in Catchup shuffle mode."
+msgstr ""
+
+msgctxt "#35016"
+msgid "Shuffle Catchup: max unwatched episodes per series"
+msgstr ""
+
+msgctxt "#35017"
+msgid "Only include a series in Catchup mode when it has this many or fewer unwatched episodes left."
+msgstr ""
+
+msgctxt "#35018"
+msgid "Shuffle All"
+msgstr ""


### PR DESCRIPTION
The library Shuffle button opens a Shuffle Mode popup.

TV libraries:
- Unwatched: random never-started series, played from the start
- Rewatch: random fully-watched series, played from the start
- Catchup: unwatched episodes of started series with few left (configurable number of series and max unwatched per series), preserving per-show episode order
- Shuffle All: the classic server-side random shuffle

Movie libraries:
- Unwatched: random never-started movies,
- Rewatch: random fully-watched movie
- Shuffle All: classic server-side shuffle

Pure selection logic lives in lib/shuffle.py; episode ordering reuses playlist.reorder_with_specials so the tv_specials_order setting is honoured. Adds two Catchup user settings. Other section types keep the classic instant shuffle.