### PR TITLE
Feature: add JSON-RPC deep link play support

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -2276,6 +2276,36 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
                     pass
                 return self.doUpdate()
 
+    def deeplink_responder(self):
+        if not util.getGlobalProperty("deeplink_play"):
+            return
+        data = util.getGlobalProperty("deeplink_play", consume=True)
+        if xbmc.Player().isPlayingVideo():
+            return
+
+        kwargs = json.loads(data)
+        if time.time() - kwargs.get("ts", 0) > 60:
+            return
+
+        key = kwargs.get("rating_key")
+        uuid = kwargs.get("server_uuid")
+        start_over = kwargs.get("start_over")
+
+        util.LOG("Home: Deep-link play requested for: {0}".format(key))
+
+        server = plexapp.SERVERMANAGER.selectedServer
+        if uuid:
+            server = plexapp.SERVERMANAGER.getServer(uuid)
+            if not server:
+                return
+
+        try:
+            command = opener.open(key, auto_play=True, server=server, start_over=start_over, dialog_props=self.carriedProps)
+            if command == "NODATA":
+                raise util.NoDataException
+        except util.NoDataException:
+            util.ERROR("No data - deleted or server disconnected?", notify=True, time_ms=5000)
+
     def tick(self):
         if self._shuttingDown:
             util.DEBUG_LOG("Home: Not ticking, shutdown flag set")
@@ -2284,6 +2314,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver, CommonMixin, SpoilersMix
         if self.movingSection:
             util.DEBUG_LOG("Home: Not ticking, currently moving a section")
             return
+
+        self.deeplink_responder()
 
         if self.is_active and self.service_responder():
             util.DEBUG_LOG("Home: Not ticking, service responder signalled positive exit")

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
+import json
 import sys
+import time
+from urllib.parse import parse_qs
 from lib.kodi_util import ensureHome, xbmc
+from lib.properties import setGlobalProperty
 
 
 def main():
@@ -9,6 +13,21 @@ def main():
 
         if data == "stub":
             return
+
+        # Check for JSON-RPC Addons.ExecuteAddon deep-link play request.
+        params = parse_qs(data)
+        action = params.get("action", [""])[0]
+        rating_key = params.get("rating_key", [""])[0]
+        if action == "play" and rating_key:
+            server_uuid = params.get("server_uuid", [""])[0]
+            start_over = params.get("start_over", [""])[0].lower() in ("1", "true")
+            play_arg = json.dumps({
+                "rating_key":  rating_key,
+                "server_uuid": server_uuid,
+                "start_over": start_over,
+                "ts": time.time(),
+            })
+            setGlobalProperty("deeplink_play", play_arg, wait=True)
     except:
         pass
     # This is a hack since it's both a plugin and a script. My Addons and Shortcuts otherwise can't launch the add-on


### PR DESCRIPTION
Allow PM4K's player to be triggered via Kodi's JSON-RPC interface. e.g.:

    curl --user kodi:kodi \
    --json '{' \
    --json '  "jsonrpc": "2.0",' \
    --json '  "id": 1,' \
    --json '  "method": "Addons.ExecuteAddon",' \
    --json '  "params": {' \
    --json '    "addonid": "script.plexmod",' \
    --json '    "params": {' \
    --json '      "action": "play",' \
    --json '      "rating_key": "12345",' \
    --json '      "server_uuid": "07ce33182249429c9210adc369008a79",' \
    --json '      "start_over": "1"' \
    --json '    }' \
    --json '  }' \
    --json '}' \
    http://kodi.example.com:8080/jsonrpc

The `server_uuid` and `start_over` params are optional. The `start_over` param accepts `1` or `true` to restart an in-progress video from the start. It is not possible to auto-resume an in-progress video unless the user has the auto-resume setting enabled.

Works whether the PM4K is cold-started or already running, but is ignored if the PM4K player is already playing something else.

