### PR TITLE
feat: show all available ratings on movies, shows and episodes

### DIFF
--- a/lib/_included_packages/plexnet/media.py
+++ b/lib/_included_packages/plexnet/media.py
@@ -257,6 +257,10 @@ class Genre(MediaTag):
     ID = '1'
 
 
+class Rating(MediaTag):
+    TYPE = 'Rating'
+
+
 class Mood(MediaTag):
     TYPE = 'Mood'
     FILTER = 'mood'

--- a/lib/_included_packages/plexnet/video.py
+++ b/lib/_included_packages/plexnet/video.py
@@ -747,6 +747,7 @@ class Movie(PlayableVideo):
             self.countries = plexobjects.PlexItemList(data, media.Country, media.Country.TYPE, server=self.server)
             self.directors = plexobjects.PlexItemList(data, media.Director, media.Director.TYPE, server=self.server)
             self.genres = plexobjects.PlexItemList(data, media.Genre, media.Genre.TYPE, server=self.server)
+            self.ratings = plexobjects.PlexItemList(data, media.Rating, media.Rating.TYPE, server=self.server)
             self.media = plexobjects.PlexMediaItemList(data, plexmedia.PlexMedia, media.Media.TYPE,
                                                        initpath=self.initpath, server=self.server, media=self)
             self.producers = plexobjects.PlexItemList(data, media.Producer, media.Producer.TYPE, server=self.server)
@@ -990,6 +991,7 @@ class Show(CachableItemsMixin, Video, media.RelatedMixin, SectionOnDeckMixin):
                                                   container=self.container)
             self.roles = plexobjects.PlexItemList(data, media.Role, media.Role.TYPE, server=self.server, container=self.container)
             self.guids = plexobjects.PlexItemList(data, media.Guid, media.Guid.TYPE, server=self.server)
+            self.ratings = plexobjects.PlexItemList(data, media.Rating, media.Rating.TYPE, server=self.server)
             #self.related = plexobjects.PlexItemList(data.find('Related'), plexlibrary.Hub, plexlibrary.Hub.TYPE, server=self.server, container=self)
             self.extras = PlexVideoItemList(data.find('Extras'), initpath=self.initpath, server=self.server, container=self)
             self.onDeck = PlexVideoItemList(data.find('OnDeck'), initpath=self.initpath, server=self.server,
@@ -1145,6 +1147,7 @@ class Episode(PlayableVideo, SectionOnDeckMixin):
             self._roles = plexobjects.PlexItemList(data, media.Role, media.Role.TYPE, server=self.server)
             self.media = plexobjects.PlexMediaItemList(data, plexmedia.PlexMedia, media.Media.TYPE, initpath=self.initpath, server=self.server, media=self)
             self.writers = plexobjects.PlexItemList(data, media.Writer, media.Writer.TYPE, server=self.server)
+            self.ratings = plexobjects.PlexItemList(data, media.Rating, media.Rating.TYPE, server=self.server)
         else:
             if data.find(media.Media.TYPE) is not None:
                 self.media = plexobjects.PlexMediaItemList(data, plexmedia.PlexMedia, media.Media.TYPE, initpath=self.initpath, server=self.server, media=self)

--- a/lib/ratings.py
+++ b/lib/ratings.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+from __future__ import absolute_import
+
+RT_PREFIX = 'rottentomatoes:'
+
+
+def sanitize(image):
+    return image.replace('themoviedb', 'tmdb').replace('://', '/')
+
+
+def format_value(image, value):
+    if image.startswith(RT_PREFIX):
+        return '{0}%'.format(int(float(value) * 10))
+    return str(value)
+
+
+def image_path(image):
+    if not image:
+        return ''
+    return 'script.plex/ratings/{0}.png'.format(sanitize(image))
+
+
+def slot_name(i):
+    return 'rating' if i == 1 else 'rating{0}'.format(i)
+
+
+def build_rating_properties(entries):
+    """Transform (image, value) pairs into numbered display properties.
+
+    Returns an ordered list of (property_name, property_value) tuples,
+    always ending with ('rating.count', str(count)). Entries with an empty
+    value are skipped; entries with an empty image set the value only.
+    """
+    props = []
+    count = 0
+    for image, value in entries:
+        if value in (None, ''):
+            continue
+        count += 1
+        name = slot_name(count)
+        props.append((name, format_value(image, value)))
+        path = image_path(image)
+        if path:
+            props.append((name + '.image', path))
+    props.append(('rating.count', str(count)))
+    return props

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -1511,6 +1511,10 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin, SeasonsMix
         mli.setProperty('writers',
                         writers and u'{0}{1}    {2}'.format(directors and '    ' or '', writersLabel, writers) or '')
 
+        # Re-populate from the full (reloaded) object so all available ratings
+        # show; the list-build pass only has the partial leaf (single rating).
+        self.populateRatings(video, mli, hide_ratings=self.hideSpoilers(video) and self.noRatings)
+
     def setItemAudioAndSubtitleInfo(self, video, mli):
         if util.getSetting('use_external_audio', False) and hasattr(type(video), 'discoverExternalAudioStreams'):
             video.discoverExternalAudioStreams()

--- a/lib/windows/mixins/ratings.py
+++ b/lib/windows/mixins/ratings.py
@@ -1,14 +1,20 @@
 # coding=utf-8
 from lib import util
+from lib import ratings as ratings_logic
+
+# Upper bound on rating slots we clear each render (must be >= the max the
+# preplay template loops over) so stale badges from a previous item never linger.
+MAX_SLOTS = 8
 
 
 class RatingsMixin(object):
     def populateRatings(self, video, ref, hide_ratings=False):
-        def sanitize(src):
-            return src.replace("themoviedb", "tmdb").replace('://', '/')
-
         setProperty = getattr(ref, "setProperty")
-        getattr(ref, "setProperties")(('rating.stars', 'rating', 'rating.image', 'rating2', 'rating2.image'), '')
+
+        clear_names = ('rating.stars', 'rating.count', 'rating', 'rating.image')
+        for i in range(2, MAX_SLOTS + 1):
+            clear_names += ('rating{0}'.format(i), 'rating{0}.image'.format(i))
+        getattr(ref, "setProperties")(clear_names, '')
 
         if video.userRating:
             stars = str(int(round((video.userRating.asFloat() / 10) * 5)))
@@ -24,23 +30,18 @@ class RatingsMixin(object):
                 "series" not in util.getSetting("show_ratings")):
             return
 
-        audienceRating = video.audienceRating
-
-        if video.rating or audienceRating:
-            if video.rating:
-                rating = video.rating
-                if video.ratingImage.startswith('rottentomatoes:'):
-                    rating = '{0}%'.format(int(rating.asFloat() * 10))
-
-                setProperty('rating', rating)
-                if video.ratingImage:
-                    setProperty('rating.image', 'script.plex/ratings/{0}.png'.format(sanitize(video.ratingImage)))
-            if audienceRating:
-                if video.audienceRatingImage.startswith('rottentomatoes:'):
-                    audienceRating = '{0}%'.format(int(audienceRating.asFloat() * 10))
-                setProperty('rating2', audienceRating)
-                if video.audienceRatingImage:
-                    setProperty('rating2.image',
-                                'script.plex/ratings/{0}.png'.format(sanitize(video.audienceRatingImage)))
+        # Prefer the full <Rating> list; fall back to the two flattened
+        # attributes for items/servers that don't provide it.
+        entries = []
+        video_ratings = getattr(video, "ratings", None)
+        if video_ratings:
+            for r in video_ratings:
+                entries.append((str(r.image or ''), r.value))
         else:
-            setProperty('rating', video.rating)
+            if video.rating:
+                entries.append((str(video.ratingImage or ''), video.rating))
+            if video.audienceRating:
+                entries.append((str(video.audienceRatingImage or ''), video.audienceRating))
+
+        for name, value in ratings_logic.build_rating_properties(entries):
+            setProperty(name, value)

--- a/resources/skins/Main/1080i/templates/script-plex-episodes.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-episodes.xml.tpl
@@ -198,10 +198,10 @@
         </control>
 
         <control type="grouplist">
-            <visible>!String.IsEmpty(Container(400).ListItem.Property(rating)) | !String.IsEmpty(Container(400).ListItem.Property(rating2))</visible>
-            <posx>1560</posx>
+            <visible>!String.IsEmpty(Container(400).ListItem.Property(rating))</visible>
+            <posx>1040</posx>
             <posy>{{ vscale(50) }}</posy>
-            <width>300</width>
+            <width>820</width>
             <height>{{ vscale(32) }}</height>
             <align>right</align>
             <itemgap>15</itemgap>
@@ -224,23 +224,25 @@
                 <textcolor>FFFFFFFF</textcolor>
                 <label>$INFO[Container(400).ListItem.Property(rating)]</label>
             </control>
+            {% for i in range(2, 7) %}
             <control type="image">
-                <visible>!String.IsEmpty(Container(400).ListItem.Property(rating2))</visible>
+                <visible>!String.IsEmpty(Container(400).ListItem.Property(rating{{ i }}))</visible>
                 <posy>2</posy>
-                <width>40</width>
+                <width>63</width>
                 <height>{{ vscale(30) }}</height>
-                <texture fallback="script.plex/ratings/other/image.rating.png">$INFO[Container(400).ListItem.Property(rating2.image)]</texture>
+                <texture fallback="script.plex/ratings/other/image.rating.png">$INFO[Container(400).ListItem.Property(rating{{ i }}.image)]</texture>
                 <aspectratio align="right">keep</aspectratio>
             </control>
             <control type="label">
-                <visible>!String.IsEmpty(Container(400).ListItem.Property(rating2))</visible>
+                <visible>!String.IsEmpty(Container(400).ListItem.Property(rating{{ i }}))</visible>
                 <width>auto</width>
                 <height>{{ vscale(30) }}</height>
                 <font>font12</font>
                 <align>left</align>
                 <textcolor>FFFFFFFF</textcolor>
-                <label>$INFO[Container(400).ListItem.Property(rating2)]</label>
+                <label>$INFO[Container(400).ListItem.Property(rating{{ i }})]</label>
             </control>
+            {% endfor %}
         </control>
 
         <control type="grouplist">

--- a/resources/skins/Main/1080i/templates/script-plex-pre_play.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-pre_play.xml.tpl
@@ -215,10 +215,10 @@
             </control>
 
             <control type="grouplist">
-                <visible>!String.IsEmpty(Window.Property(rating)) | !String.IsEmpty(Window.Property(rating2))</visible>
-                <posx>1426</posx>
+                <visible>!String.IsEmpty(Window.Property(rating)) | !String.IsEmpty(Window.Property(rating.stars))</visible>
+                <posx>1040</posx>
                 <posy>4</posy>
-                <width>434</width>
+                <width>820</width>
                 <height>{{ vscale(32) }}</height>
                 <align>right</align>
                 <itemgap>15</itemgap>
@@ -241,23 +241,25 @@
                     <textcolor>FFFFFFFF</textcolor>
                     <label>$INFO[Window.Property(rating)]</label>
                 </control>
+                {% for i in range(2, 7) %}
                 <control type="image">
-                    <visible>!String.IsEmpty(Window.Property(rating2))</visible>
+                    <visible>!String.IsEmpty(Window.Property(rating{{ i }}))</visible>
                     <posy>2</posy>
-                    <width>40</width>
+                    <width>63</width>
                     <height>{{ vscale(30) }}</height>
-                    <texture fallback="script.plex/ratings/other/image.rating.png">$INFO[Window.Property(rating2.image)]</texture>
+                    <texture fallback="script.plex/ratings/other/image.rating.png">$INFO[Window.Property(rating{{ i }}.image)]</texture>
                     <aspectratio align="right">keep</aspectratio>
                 </control>
                 <control type="label">
-                    <visible>!String.IsEmpty(Window.Property(rating2))</visible>
+                    <visible>!String.IsEmpty(Window.Property(rating{{ i }}))</visible>
                     <width>auto</width>
                     <height>{{ vscale(30) }}</height>
                     <font>font12</font>
                     <align>left</align>
                     <textcolor>FFFFFFFF</textcolor>
-                    <label>$INFO[Window.Property(rating2)]</label>
+                    <label>$INFO[Window.Property(rating{{ i }})]</label>
                 </control>
+                {% endfor %}
                 <control type="image">
                     <visible>!String.IsEmpty(Window.Property(rating.stars))</visible>
                     <posy>6</posy>

--- a/resources/skins/Main/1080i/templates/script-plex-seasons.xml.tpl
+++ b/resources/skins/Main/1080i/templates/script-plex-seasons.xml.tpl
@@ -117,10 +117,10 @@
         </control>
 
         <control type="grouplist">
-            <visible>!String.IsEmpty(Window.Property(rating)) | !String.IsEmpty(Window.Property(rating2))</visible>
-            <posx>1560</posx>
+            <visible>!String.IsEmpty(Window.Property(rating))</visible>
+            <posx>1040</posx>
             <posy>{{ vscale(70) }}</posy>
-            <width>300</width>
+            <width>820</width>
             <height>{{ vscale(32) }}</height>
             <align>right</align>
             <itemgap>15</itemgap>
@@ -143,23 +143,25 @@
                 <textcolor>FFFFFFFF</textcolor>
                 <label>$INFO[Window.Property(rating)]</label>
             </control>
+            {% for i in range(2, 7) %}
             <control type="image">
-                <visible>!String.IsEmpty(Window.Property(rating2))</visible>
+                <visible>!String.IsEmpty(Window.Property(rating{{ i }}))</visible>
                 <posy>2</posy>
-                <width>40</width>
+                <width>63</width>
                 <height>{{ vscale(30) }}</height>
-                <texture fallback="script.plex/ratings/other/image.rating.png">$INFO[Window.Property(rating2.image)]</texture>
+                <texture fallback="script.plex/ratings/other/image.rating.png">$INFO[Window.Property(rating{{ i }}.image)]</texture>
                 <aspectratio align="right">keep</aspectratio>
             </control>
             <control type="label">
-                <visible>!String.IsEmpty(Window.Property(rating2))</visible>
+                <visible>!String.IsEmpty(Window.Property(rating{{ i }}))</visible>
                 <width>auto</width>
                 <height>{{ vscale(30) }}</height>
                 <font>font12</font>
                 <align>left</align>
                 <textcolor>FFFFFFFF</textcolor>
-                <label>$INFO[Window.Property(rating2)]</label>
+                <label>$INFO[Window.Property(rating{{ i }})]</label>
             </control>
+            {% endfor %}
         </control>
 
 


### PR DESCRIPTION
Plex returns a full <Rating> array (each entry image/value/type) in item metadata, but plexnet only read the two flattened primary attributes, so at most two ratings ever displayed. Parse the array and render every source (IMDB, Rotten Tomatoes critic/audience, TMDB, ...) like the Plex apps do.

- plexnet: add media.Rating and parse .ratings on Movie, Show and Episode
- lib/ratings.py: pure, unit-tested transform building numbered rating properties (rating, rating2, ...; slot 1 keeps the unsuffixed name for back-compat) with the existing RT-percentage and image-path rules
- RatingsMixin: feed ratings through the helper, falling back to the flattened rating/audienceRating when the array is absent
- templates (pre_play, seasons, episodes): loop the rating slots and widen the right-aligned row so several badges fit
- episodes: repopulate from the reloaded full object in setPostReloadItemInfo, since list leaves omit the <Rating> array
